### PR TITLE
Rename `kprovex` to `kprove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Not all TEAL opcodes are supported by the semantics as of yet. See the relevant 
 
 `kavm` is a shell script that provides a command-line interface for the semantics:
 * concrete simulations and tests are run via `krun` and the K LLVM Backend
-* symbolic execution proofs are run with `kprovex` and the K Haskell Backend
+* symbolic execution proofs are run with `kprove` and the K Haskell Backend
 
 See `kavm --help` for more information.
 

--- a/kavm
+++ b/kavm
@@ -131,9 +131,9 @@ run_krun() {
 }
 
 run_prove() {
-    local kprovex_args
-    kprovex_args=(--directory "${backend_dir}" "${run_file}")
-    execute kprovex "${kprovex_args[@]}" -I "${INSTALL_LIB}/kframework" "$@"
+    local kprove_args
+    kprove_args=(--directory "${backend_dir}" "${run_file}")
+    execute kprove "${kprove_args[@]}" -I "${INSTALL_LIB}/kframework" "$@"
 }
 
 # Helpers


### PR DESCRIPTION
This PR renames `kprovex` to `kprove` so that the `kprovex` name can be removed from the upstream K distribution.