### PR TITLE
Fix unparsing of `gloadss`

### DIFF
--- a/lib/include/kframework/avm/teal/teal-syntax.md
+++ b/lib/include/kframework/avm/teal/teal-syntax.md
@@ -30,7 +30,7 @@ module TEAL-OPCODES
                         | BranchingOpCode
                         | StackOpCode
   syntax SigOpCode    ::= SigVerOpCode | ArgOpCode           // Opcodes used only by stateless TEAL
-  syntax AppOpCode    ::= StateOpCode  
+  syntax AppOpCode    ::= StateOpCode
                         | TxnGroupStateOpCode
                         | InnerTxOpCode                      // Opcodes used only by stateful TEAL
 ```

--- a/lib/include/kframework/avm/teal/teal-syntax.md
+++ b/lib/include/kframework/avm/teal/teal-syntax.md
@@ -588,7 +588,7 @@ module TEAL-UNPARSER
   rule unparseTEAL(gload N M)                     => "gload" +&+ Int2String(N) +&+ Int2String(M)
   rule unparseTEAL(gaids)                         => "gaids"
   rule unparseTEAL(gloads N)                      => "gloads" +&+ Int2String(N)
-  rule unparseTEAL(gloadss N)                     => "gloadss" +&+ Int2String(N)
+  rule unparseTEAL(gloadss)                       => "gloadss"
   rule unparseTEAL(itxn_begin)                    => "itxn_begin"
   rule unparseTEAL(itxn_submit)                   => "itxn_submit"
   rule unparseTEAL(itxn_field FieldName)          => "itxn_field" +&+ TealField2String(FieldName:TxnField)


### PR DESCRIPTION
This PR fixes what I believe is a mis-specified rule for unparsing `gloadss`.