### PR TITLE
Minimum balance checking

### DIFF
--- a/kavm/src/kavm/kavm.py
+++ b/kavm/src/kavm/kavm.py
@@ -282,6 +282,7 @@ class KAVM(KRun):
                     'TXGROUPID_CELL': intToken(0),  # TODO: revise
                     # TODO: CURRENTTX_CELL should be of sort String in the semantics
                     'CURRENTTX_CELL': intToken(0),
+                    'TOUCHEDACCOUNTS_CELL': KApply('.Set'),
                     'RETURNCODE_CELL': intToken(4),
                     'RETURNSTATUS_CELL': stringToken('Failure - program is stuck'),
                     'GLOBALROUND_CELL': intToken(6),
@@ -335,6 +336,7 @@ class KAVM(KRun):
                 'GROUPSIZE_CELL': intToken(len(transactions)),
                 'TXGROUPID_CELL': intToken(0),  # TODO: revise
                 'CURRENTTX_CELL': intToken(transactions[0].txid),
+                'TOUCHEDACCOUNTS_CELL': KApply('.Set'),
                 'K_CELL': KApply(
                     '#evalTxGroup()_AVM-EXECUTION_AlgorandCommand',
                 ),

--- a/lib/include/kframework/avm/avm-configuration.md
+++ b/lib/include/kframework/avm/avm-configuration.md
@@ -111,7 +111,7 @@ These are AVM-specific panic behaviors, caused by issues like depleted balances,
   //---------------------------------------------------
   syntax AvmPanic ::= "ASSET_NO_PERMISSION"     [macro]
   //------------------------------------------------
-  rule MIN_BALANCE_VIOLATION   => "sender account's balance falls below its allowed minimum balance"
+  rule MIN_BALANCE_VIOLATION   => "account's balance falls below its allowed minimum balance"
   rule UNSUPPORTED_TXN_TYPE    => "attempt to execute an unsupported transaction type"
   rule ASSET_FROZEN_FOR_SENDER => "attempt to send frozen asset holdings"
   rule ASSET_NOT_OPT_IN        => "either sender or receiver have not opted into asset"
@@ -121,7 +121,7 @@ These are AVM-specific panic behaviors, caused by issues like depleted balances,
   syntax AlgorandCommand ::= #avmPanic(Int, AvmPanic)
   //-------------------------------------------
   rule <k> #avmPanic(TXN_ID, S) ~> _ => .K </k>
-       <returncode> 4 => 3 </returncode>
+       <returncode> _ => 3 </returncode>
        <returnstatus> _ => "Failure - when executing transaction " +String Int2String(TXN_ID)
                            +String ": " +String S
        </returnstatus>

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -73,7 +73,7 @@ and the current configuration is frozen for examination.
        <deque> TXN_DEQUE </deque>
     requires TXN_DEQUE =/=K .List
 
-  rule <k> #evalTxGroup() => .K ... </k>
+  rule <k> #evalTxGroup() => #checkSufficientBalance() ... </k>
       <returncode> _ => 0 </returncode>
       <returnstatus> _ => "Success - transaction group accepted"
       </returnstatus>
@@ -99,7 +99,6 @@ the attached stateless TEAL if the transaction is logicsig-signed.
   rule <k> #evalTx() => 
              #checkTxnSignature() 
           ~> #executeTxn(TXN_TYPE) 
-          ~> #checkSufficientBalance(SENDER_ADDR)
        ... 
        </k>
        <currentTx> TXN_ID </currentTx>
@@ -109,6 +108,7 @@ the attached stateless TEAL if the transaction is logicsig-signed.
          <sender> SENDER_ADDR </sender>
          ...
        </transaction>
+       <touchedAccounts> .Set => SetItem(SENDER_ADDR) ...</touchedAccounts>
 
 ```
 
@@ -293,6 +293,14 @@ Add asset to account
 ```
 
 ```k
+  syntax AlgorandCommand ::= #checkSufficientBalance()
+  //--------------------------------------------------
+  rule <k> #checkSufficientBalance() => (#checkSufficientBalance(ADDR) ~> #checkSufficientBalance()) ...</k>
+       <touchedAccounts> (SetItem(ADDR) => .Set) ...</touchedAccounts>
+
+  rule <k> #checkSufficientBalance() => . ...</k>
+       <touchedAccounts> .Set </touchedAccounts>
+  
   syntax AlgorandCommand ::= #checkSufficientBalance(Bytes)
   //-------------------------------------------------------
   rule <k> #checkSufficientBalance(ADDR) => . ...</k>
@@ -304,7 +312,8 @@ Add asset to account
        </account>
     requires BALANCE >=Int MIN_BALANCE
 
-  rule <k> #checkSufficientBalance(ADDR) => panic(INSUFFICIENT_FUNDS) ...</k>
+  rule <k> #checkSufficientBalance(ADDR) => #avmPanic(TX_ID, MIN_BALANCE_VIOLATION) ...</k>
+       <currentTx> TX_ID </currentTx>
        <account>
          <address> ADDR </address>
          <balance> BALANCE </balance>
@@ -364,7 +373,6 @@ Overflow on subtraction is impossible because the minimum balance is at least 0.
        <account>
          <address> SENDER </address>
          <balance> SENDER_BALANCE => SENDER_BALANCE -Int AMOUNT </balance>
-         <minBalance> SENDER_MIN_BALANCE </minBalance>
          ...
        </account>
        <account>
@@ -372,9 +380,9 @@ Overflow on subtraction is impossible because the minimum balance is at least 0.
          <balance> RECEIVER_BALANCE => RECEIVER_BALANCE +Int AMOUNT </balance>
          ...
        </account>
-    requires SENDER_BALANCE -Int AMOUNT >=Int SENDER_MIN_BALANCE
+       <touchedAccounts> (.Set => SetItem(RECEIVER)) ...</touchedAccounts>
 
-  rule <k> #executeTxn(@pay) => #avmPanic(TXN_ID, MIN_BALANCE_VIOLATION) ... </k>
+  rule <k> #executeTxn(@pay) => panic(INSUFFICIENT_FUNDS) ... </k>
        <currentTx> TXN_ID </currentTx>
        <transaction>
          <txID>     TXN_ID   </txID>
@@ -385,10 +393,9 @@ Overflow on subtraction is impossible because the minimum balance is at least 0.
        <account>
          <address> SENDER </address>
          <balance> SENDER_BALANCE </balance>
-         <minBalance> SENDER_MIN_BALANCE </minBalance>
          ...
        </account>
-    requires SENDER_BALANCE -Int AMOUNT <Int SENDER_MIN_BALANCE
+    requires SENDER_BALANCE -Int AMOUNT <Int 0
 
   rule <k> #executeTxn(@pay) => #avmPanic(TXN_ID, UNKNOWN_ADDRESS) ... </k>
        <currentTx> TXN_ID </currentTx>

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -99,12 +99,14 @@ the attached stateless TEAL if the transaction is logicsig-signed.
   rule <k> #evalTx() => 
              #checkTxnSignature() 
           ~> #executeTxn(TXN_TYPE) 
+          ~> #checkSufficientBalance(SENDER_ADDR)
        ... 
        </k>
        <currentTx> TXN_ID </currentTx>
        <transaction>
          <txID> TXN_ID </txID>
          <typeEnum> TXN_TYPE </typeEnum>
+         <sender> SENDER_ADDR </sender>
          ...
        </transaction>
 
@@ -288,6 +290,28 @@ Add asset to account
          ...
        </account>
        requires (BALANCE +Int AMOUNT) >=Int 0
+```
+
+```k
+  syntax AlgorandCommand ::= #checkSufficientBalance(Bytes)
+  //-------------------------------------------------------
+  rule <k> #checkSufficientBalance(ADDR) => . ...</k>
+       <account>
+         <address> ADDR </address>
+         <balance> BALANCE </balance>
+         <minBalance> MIN_BALANCE </minBalance>
+         ...
+       </account>
+    requires BALANCE >=Int MIN_BALANCE
+
+  rule <k> #checkSufficientBalance(ADDR) => panic(INSUFFICIENT_FUNDS) ...</k>
+       <account>
+         <address> ADDR </address>
+         <balance> BALANCE </balance>
+         <minBalance> MIN_BALANCE </minBalance>
+         ...
+       </account>
+    requires BALANCE <Int MIN_BALANCE
 ```
 
 #### (Optional) Eval TEAL

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -73,6 +73,7 @@ and the current configuration is frozen for examination.
        <deque> TXN_DEQUE </deque>
     requires TXN_DEQUE =/=K .List
 
+  // Minimum balances are only checked at the conclusion of the outer-level group.
   rule <k> #evalTxGroup() => #checkSufficientBalance() ... </k>
       <returncode> _ => 0 </returncode>
       <returnstatus> _ => "Success - transaction group accepted"

--- a/lib/include/kframework/avm/avm-initialization.md
+++ b/lib/include/kframework/avm/avm-initialization.md
@@ -41,6 +41,7 @@ The transaction is initialized first.
          <transactions>
            _ => .Bag
           </transactions>
+          <touchedAccounts> _ => .Set </touchedAccounts>
        </txGroup>
 ```
 

--- a/lib/include/kframework/avm/avm-initialization.md
+++ b/lib/include/kframework/avm/avm-initialization.md
@@ -41,6 +41,8 @@ The transaction is initialized first.
          <transactions>
            _ => .Bag
           </transactions>
+          // Accounts that have been modified during this (top-level) transaction group: those for which it will be checked
+          // that their balance has not gone below their minimum balance. 
           <touchedAccounts> _ => .Set </touchedAccounts>
        </txGroup>
 ```

--- a/lib/include/kframework/avm/teal/teal-execution.md
+++ b/lib/include/kframework/avm/teal/teal-execution.md
@@ -342,6 +342,7 @@ return code to 3 (see return codes below).
   syntax String ::= "CALLSTACK_OVERFLOW"         [macro]
   syntax String ::= "INVALID_ARGUMENT"           [macro]
   syntax String ::= "MATH_BYTES_ARG_TOO_LONG"    [macro]
+  syntax String ::= "INSUFFICIENT_FUNDS"         [macro]
   //----------------------------------------------------
   rule INVALID_OP_FOR_MODE => "invalid opcode for current execution mode"
   rule ERR_OPCODE          => "err opcode encountered"
@@ -367,13 +368,14 @@ return code to 3 (see return codes below).
   rule CALLSTACK_UNDERFLOW => "call stack underflow: illegal retsub"
   rule CALLSTACK_OVERFLOW  => "call stack overflow: recursion is too deep"
   rule MATH_BYTES_ARG_TOO_LONG => "math attempted on large byte-array"
+  rule INSUFFICIENT_FUNDS  => "transaction would cause balance to go under the minimum balance"
   rule ASSERTION_VIOLATION => "assertion violation"
   //--------------------------------------------------------------------------------
 
   syntax KItem ::= panic(String)
   // ---------------------------
   rule <k> panic(S) ~> _ => .K </k>
-       <returncode> 4 => 3 </returncode>
+       <returncode> _ => 3 </returncode>
        <returnstatus> _ => "Failure - panic: " +String S </returnstatus>
 ```
 

--- a/lib/include/kframework/avm/teal/teal-execution.md
+++ b/lib/include/kframework/avm/teal/teal-execution.md
@@ -368,7 +368,7 @@ return code to 3 (see return codes below).
   rule CALLSTACK_UNDERFLOW => "call stack underflow: illegal retsub"
   rule CALLSTACK_OVERFLOW  => "call stack overflow: recursion is too deep"
   rule MATH_BYTES_ARG_TOO_LONG => "math attempted on large byte-array"
-  rule INSUFFICIENT_FUNDS  => "transaction would cause balance to go under the minimum balance"
+  rule INSUFFICIENT_FUNDS  => "negative balance reached"
   rule ASSERTION_VIOLATION => "assertion violation"
   //--------------------------------------------------------------------------------
 

--- a/lib/include/kframework/avm/txn.md
+++ b/lib/include/kframework/avm/txn.md
@@ -162,6 +162,7 @@ Transaction Group State Representation
 module ALGO-TXN
   imports TXN-FIELDS
   imports TEAL-TYPES
+  imports SET
 ```
 
 *Transaction Group Configuration*
@@ -191,6 +192,7 @@ module ALGO-TXN
             <assetFreezeTxFields/>
           </transaction>
         </transactions>
+        <touchedAccounts> .Set </touchedAccounts>
       </txGroup>
 ```
 

--- a/tests/scenarios/app-account.avm-simulation
+++ b/tests/scenarios/app-account.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-account.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-global-get-ex-app-unavailable.fail.avm-simulation
+++ b/tests/scenarios/app-global-get-ex-app-unavailable.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-global-get-ex-app-unavailable.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-global-get-ex.avm-simulation
+++ b/tests/scenarios/app-global-get-ex.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-global-get-ex.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-local-get-ex-app-unavailable.fail.avm-simulation
+++ b/tests/scenarios/app-local-get-ex-app-unavailable.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-get-ex-app-unavailable.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-local-get-ex.avm-simulation
+++ b/tests/scenarios/app-local-get-ex.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-get-ex.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 550000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-local-get-fake-account.fail.avm-simulation
+++ b/tests/scenarios/app-local-get-fake-account.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-get-fake-account.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-local-get-not-opted-in.fail.avm-simulation
+++ b/tests/scenarios/app-local-get-not-opted-in.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-get-not-opted-in.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-local-get.avm-simulation
+++ b/tests/scenarios/app-local-get.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-get.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-local-put-not-opted-in.fail.avm-simulation
+++ b/tests/scenarios/app-local-put-not-opted-in.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-local-put-not-opted-in.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 350000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-opted-in-account-invalid.fail.avm-simulation
+++ b/tests/scenarios/app-opted-in-account-invalid.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in-account-invalid.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-opted-in-account-invalid2.fail.avm-simulation
+++ b/tests/scenarios/app-opted-in-account-invalid2.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in-account-invalid2.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-opted-in-app-invalid.fail.avm-simulation
+++ b/tests/scenarios/app-opted-in-app-invalid.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in-app-invalid.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-opted-in-ill-typed.fail.avm-simulation
+++ b/tests/scenarios/app-opted-in-ill-typed.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in-ill-typed.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/app-opted-in-offsets.avm-simulation
+++ b/tests/scenarios/app-opted-in-offsets.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in-offsets.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/app-opted-in.avm-simulation
+++ b/tests/scenarios/app-opted-in.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-opted-in.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/arithmetic-add-mul-div-sub.avm-simulation
+++ b/tests/scenarios/arithmetic-add-mul-div-sub.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "arithmetic-add-mul-div-sub.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/arithmetic-add-overflow.fail.avm-simulation
+++ b/tests/scenarios/arithmetic-add-overflow.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "arithmetic-add-overflow.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/arithmetic-div0.fail.avm-simulation
+++ b/tests/scenarios/arithmetic-div0.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "arithmetic-div0.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/arithmetic-ill-typed.fail.avm-simulation
+++ b/tests/scenarios/arithmetic-ill-typed.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "arithmetic-ill-typed.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
              

--- a/tests/scenarios/asset-holding-get-asset-invalid.fail.avm-simulation
+++ b/tests/scenarios/asset-holding-get-asset-invalid.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "asset-holding-get-asset-invalid.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 
@@ -31,8 +31,8 @@ addAppCallTx <txID> 1 </txID>
              <foreignAssets>     0           </foreignAssets>
              <globalNui>         0           </globalNui>
              <globalNbs>         0           </globalNbs>
-             <localNui>          1           </localNui>
-             <localNbs>          2           </localNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
              <extraProgramPages> 0           </extraProgramPages>
              <approvalPgmIdx>    0           </approvalPgmIdx>
              <clearStatePgmIdx>  1           </clearStatePgmIdx>;

--- a/tests/scenarios/asset-holding-get.avm-simulation
+++ b/tests/scenarios/asset-holding-get.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "asset-holding-get.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 400000 </balance>;
+addAccount <address> b"2" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/asset-params-get.avm-simulation
+++ b/tests/scenarios/asset-params-get.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "asset-params-get.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/balance-account-not-available.fail.avm-simulation
+++ b/tests/scenarios/balance-account-not-available.fail.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "balance-account-not-available.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
-addAccount <address> b"2" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 654321 </balance>;
+addAccount <address> b"2" </address> <balance> 654321 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/balance-offset-out-of-bounds.fail.avm-simulation
+++ b/tests/scenarios/balance-offset-out-of-bounds.fail.avm-simulation
@@ -1,10 +1,10 @@
 declareTealSource "balance-offset-out-of-bounds.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
-addAccount <address> b"2" </address> <balance> 12345 </balance>;
-addAccount <address> b"3" </address> <balance> 12345 </balance>;
-addAccount <address> b"4" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 654321 </balance>;
+addAccount <address> b"2" </address> <balance> 654321 </balance>;
+addAccount <address> b"3" </address> <balance> 654321 </balance>;
+addAccount <address> b"4" </address> <balance> 654321 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/balance-offset.avm-simulation
+++ b/tests/scenarios/balance-offset.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "balance-offset.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 654321 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/balance.avm-simulation
+++ b/tests/scenarios/balance.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "balance.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 654321 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/concat-overfill.fail.avm-simulation
+++ b/tests/scenarios/concat-overfill.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "concat-overfill.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/concat.avm-simulation
+++ b/tests/scenarios/concat.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "concat.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/count-calls.avm-simulation
+++ b/tests/scenarios/count-calls.avm-simulation
@@ -15,8 +15,8 @@
 declareTealSource "count_calls.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 300000 </balance>;
-addAccount <address> b"2" </address> <balance> 200000 </balance>;
+addAccount <address> b"1" </address> <balance> 357000 </balance>;
+addAccount <address> b"2" </address> <balance> 228500 </balance>;
 
 #initTxGroup();
 
@@ -74,6 +74,3 @@ addAppCallTx <txID> 2 </txID>
 #initGlobals();
 #evalTxGroup();
 .AS
-
-
-

--- a/tests/scenarios/count-calls.avm-simulation
+++ b/tests/scenarios/count-calls.avm-simulation
@@ -15,8 +15,8 @@
 declareTealSource "count_calls.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
-addAccount <address> b"2" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
+addAccount <address> b"2" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/duplicate-label.fail.avm-simulation
+++ b/tests/scenarios/duplicate-label.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "duplicate-label.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/insufficient-funds.fail.avm-simulation
+++ b/tests/scenarios/insufficient-funds.fail.avm-simulation
@@ -1,0 +1,21 @@
+declareTealSource "clear-basic.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
+addAccount <address> b"2" </address> <balance> 10000000 </balance>;
+
+#initTxGroup();
+
+// Pay b"2". This should fail even though later in the same group the funds are given back, because it would
+// cause b"1"'s balance to go negative.
+addPaymentTx <txID>     0     </txID>
+             <sender>   b"1"  </sender>
+             <receiver> b"2"  </receiver>
+             <amount>   300000 </amount>;
+
+addPaymentTx <txID>     1     </txID>
+             <sender>   b"2"  </sender>
+             <receiver> b"1"  </receiver>
+             <amount>   300000 </amount>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/loads-out-of-bounds.fail.avm-simulation
+++ b/tests/scenarios/loads-out-of-bounds.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "loads-out-of-bounds.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/loads.avm-simulation
+++ b/tests/scenarios/loads.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "loads.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/loop.avm-simulation
+++ b/tests/scenarios/loop.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "loop.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-app-clearstate.avm-simulation
+++ b/tests/scenarios/min-balance-app-clearstate.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-app-clearstate.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 1485000 </balance>;
+addAccount <address> b"2" </address> <balance> 721000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-app-closeout.avm-simulation
+++ b/tests/scenarios/min-balance-app-closeout.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-app-closeout.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 1485000 </balance>;
+addAccount <address> b"2" </address> <balance> 721000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-app-create.avm-simulation
+++ b/tests/scenarios/min-balance-app-create.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "min-balance-app-create.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 864000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-app-delete.avm-simulation
+++ b/tests/scenarios/min-balance-app-delete.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-app-delete.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
+addAccount <address> b"2" </address> <balance> 864000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-app-optin.avm-simulation
+++ b/tests/scenarios/min-balance-app-optin.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-app-optin.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 564000 </balance>;
+addAccount <address> b"2" </address> <balance> 664000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-asset-destroy.avm-simulation
+++ b/tests/scenarios/min-balance-asset-destroy.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-asset-destroy.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
+addAccount <address> b"2" </address> <balance> 300000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-asset-opt-out.avm-simulation
+++ b/tests/scenarios/min-balance-asset-opt-out.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-asset-opt-out.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 400000 </balance>;
+addAccount <address> b"2" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-create-asset.avm-simulation
+++ b/tests/scenarios/min-balance-create-asset.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-create-asset.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
+addAccount <address> b"2" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-default.avm-simulation
+++ b/tests/scenarios/min-balance-default.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "min-balance-default.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
 addAccount <address> b"2" </address> <balance> 100000 </balance>;
 
 #initTxGroup();

--- a/tests/scenarios/min-balance-optin-asset.avm-simulation
+++ b/tests/scenarios/min-balance-optin-asset.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "min-balance-optin-asset.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 100000 </balance>;
-addAccount <address> b"2" </address> <balance> 100000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
+addAccount <address> b"2" </address> <balance> 400000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/min-balance-receiver.fail.avm-simulation
+++ b/tests/scenarios/min-balance-receiver.fail.avm-simulation
@@ -1,0 +1,15 @@
+declareTealSource "clear-basic.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
+addAccount <address> b"2" </address> <balance> 0 </balance>;
+
+#initTxGroup();
+
+// Pay b"2". This group should fail because b"2"'s balance is 100, less than their mininum of 100000.
+addPaymentTx <txID>     0     </txID>
+             <sender>   b"1"  </sender>
+             <receiver> b"2"  </receiver>
+             <amount>   100 </amount>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/min-balance-recover-later.avm-simulation
+++ b/tests/scenarios/min-balance-recover-later.avm-simulation
@@ -1,0 +1,33 @@
+declareTealSource "clear-basic.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000 </balance>;
+addAccount <address> b"2" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Add app, bringing min balance to 200000. This is higher than the current balance, but it is still OK if we
+// fund our account later in the transaction group.
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Pay b"1", bringing their balance up to the new minimum.
+addPaymentTx <txID>     1     </txID>
+             <sender>   b"2"  </sender>
+             <receiver> b"1"  </receiver>
+             <amount>   100000 </amount>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/min-balance-violation.fail.avm-simulation
+++ b/tests/scenarios/min-balance-violation.fail.avm-simulation
@@ -1,0 +1,32 @@
+declareTealSource "clear-basic.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
+addAccount <address> b"2" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Add app, bringing min balance to 200000.
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Pay b"2", sending balance to below b"1"'s minumum.
+addPaymentTx <txID>     1     </txID>
+             <sender>   b"1"  </sender>
+             <receiver> b"2"  </receiver>
+             <amount>   100 </amount>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/stack-dig.avm-simulation
+++ b/tests/scenarios/stack-dig.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "stack-dig.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/stack-ill-typed.fail.avm-simulation
+++ b/tests/scenarios/stack-ill-typed.fail.avm-simulation
@@ -1,11 +1,11 @@
 declareTealSource "stack-ill-typed.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 
-// Add app and opt in b"1"
+// Add app 
 addAppCallTx <txID> 0 </txID>
              <sender>            b"1"        </sender>
              <applicationID>     0           </applicationID>

--- a/tests/scenarios/stack-too-deep.fail.avm-simulation
+++ b/tests/scenarios/stack-too-deep.fail.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "stack-too-deep.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/storage-limit-overwrite.avm-simulation
+++ b/tests/scenarios/storage-limit-overwrite.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "storage-limit-overwrite.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 12345 </balance>;
+addAccount <address> b"1" </address> <balance> 457000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/transaction-group-test.avm-simulation
+++ b/tests/scenarios/transaction-group-test.avm-simulation
@@ -1,8 +1,8 @@
 declareTealSource "transaction-group-test.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
-addAccount <address> b"2" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 300000 </balance>;
+addAccount <address> b"2" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 

--- a/tests/scenarios/txnas-stacksize.avm-simulation
+++ b/tests/scenarios/txnas-stacksize.avm-simulation
@@ -1,11 +1,11 @@
 declareTealSource "txnas-stacksize.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 200000 </balance>;
 
 #initTxGroup();
 
-// Add app and opt in b"1"
+// Add app
 addAppCallTx <txID> 0 </txID>
              <sender>            b"1"        </sender>
              <applicationID>     0           </applicationID>

--- a/tests/teal-sources/balance-offset-out-of-bounds.teal
+++ b/tests/teal-sources/balance-offset-out-of-bounds.teal
@@ -1,6 +1,6 @@
 #pragma version 5
 
-int 12345
+int 654321
 
 int 4
 balance

--- a/tests/teal-sources/balance-offset.teal
+++ b/tests/teal-sources/balance-offset.teal
@@ -1,6 +1,6 @@
 #pragma version 5
 
-int 12345
+int 654321
 
 int 0
 balance

--- a/tests/teal-sources/balance.teal
+++ b/tests/teal-sources/balance.teal
@@ -1,13 +1,13 @@
 #pragma version 5
 
-int 12345
+int 654321
 
 txn Sender
 balance
 ==
 assert
 
-int 54321
+int 123456
 
 txn Sender
 balance


### PR DESCRIPTION
This PR adds logic to reject a transaction if it would result in the sender being below their minimum balance. I was not sure if there were other cases to consider where other accounts besides the sender might be sent below the minimum balance. The documentation says "If ever a transaction is sent that would result in a balance lower than the minimum, the transaction will fail". There are of course inner transactions which can pay out from and charge fees to the application account, but this should handle those, in theory, since they are planned to be just their own transactions where the application account is the sender.

Edit: The receiver in a payment transaction also needs to have their minimum balance checked at the end of a transaction group. 