### PR TITLE
Inner transaction tests

### DIFF
--- a/lib/include/kframework/avm/teal/teal-fields.md
+++ b/lib/include/kframework/avm/teal/teal-fields.md
@@ -71,6 +71,10 @@ module TEAL-FIELDS
 ### `txn`/`gtxn` fields
 
 ```k
+
+  syntax TxnFieldTop ::= TxnField
+                       | TxnaFieldExt
+
   syntax TxnField ::= TxnStaticField
                     | TxnDynamicField
 

--- a/lib/include/kframework/avm/teal/teal-fields.md
+++ b/lib/include/kframework/avm/teal/teal-fields.md
@@ -73,7 +73,7 @@ module TEAL-FIELDS
 ```k
 
   syntax TxnFieldTop ::= TxnField
-                       | TxnaFieldExt
+                       | TxnaField
 
   syntax TxnField ::= TxnStaticField
                     | TxnDynamicField
@@ -157,10 +157,6 @@ module TEAL-FIELDS
                            | "Assets"
 
   syntax TxnaDynamicField ::= "Logs"
-
-  syntax TxnaFieldExt ::= TxnaField
-//                        | "Applications"
-//                        | "Assets"
 ```
 
 ### `acct_params` fields

--- a/lib/include/kframework/avm/teal/teal-fields.md
+++ b/lib/include/kframework/avm/teal/teal-fields.md
@@ -71,7 +71,7 @@ module TEAL-FIELDS
 ### `txn`/`gtxn` fields
 
 ```k
-
+// Needed because itxn_field accepts both singular and array fields as arguments
   syntax TxnFieldTop ::= TxnField
                        | TxnaField
 

--- a/lib/include/kframework/avm/teal/teal-syntax.md
+++ b/lib/include/kframework/avm/teal/teal-syntax.md
@@ -610,7 +610,7 @@ module TEAL-UNPARSER
                   | TealField2String(AssetParamsField)   [function]
                   | TealField2String(AppParamsField)     [function]
                   | TealField2String(TxnField)           [function]
-                  | TealField2String(TxnaFieldExt)       [function]
+                  | TealField2String(TxnaField)          [function]
                   | TealField2String(AccountParamsField) [function]
   // ---------------------------------------------------------------------------------------
   rule TealField2String(MinTxnFee)                => "MinTxnFee"

--- a/lib/include/kframework/avm/teal/teal-syntax.md
+++ b/lib/include/kframework/avm/teal/teal-syntax.md
@@ -335,7 +335,12 @@ module TEAL-OPCODES
 ```k
   syntax InnerTxOpCode ::= "itxn_begin"
                          | "itxn_submit"
-                         | "itxn_field" TxnField
+                         | "itxn_field" TxnFieldTop
+                         | "itxn_next"
+                         | "itxn" TxnField
+                         | "itxna" TxnaField Int
+                         | "gitxn" Int TxnField
+                         | "gitxna" Int TxnaField Int
 ```
 
 ```k
@@ -587,6 +592,11 @@ module TEAL-UNPARSER
   rule unparseTEAL(itxn_begin)                    => "itxn_begin"
   rule unparseTEAL(itxn_submit)                   => "itxn_submit"
   rule unparseTEAL(itxn_field FieldName)          => "itxn_field" +&+ TealField2String(FieldName:TxnField)
+  rule unparseTEAL(itxn_next)                     => "itxn_next"
+  rule unparseTEAL(itxn FieldName)                => "itxn" +&+ TealField2String(FieldName:TxnField)
+  rule unparseTEAL(itxna FieldName N)             => "itxna" +&+ TealField2String(FieldName:TxnField) +&+ Int2String(N)
+  rule unparseTEAL(gitxn T FieldName)             => "itxn" +&+ Int2String(T) +&+ TealField2String(FieldName:TxnField)
+  rule unparseTEAL(gitxna T FieldName N)          => "itxna" +&+ Int2String(T) +&+ TealField2String(FieldName:TxnField) +&+ Int2String(N)
 
   syntax String ::= left:
                     String "+&+" String       [function]

--- a/lib/include/kframework/avm/txn.md
+++ b/lib/include/kframework/avm/txn.md
@@ -215,9 +215,9 @@ module ALGO-TXN
   rule [[ getCurrentTxn() => I ]]
     <currentTx> I </currentTx>
 
-  syntax MaybeTValue ::= getTxnField(Int, TxnField)          [function, functional]
-  syntax MaybeTValue ::= getTxnField(Int, TxnaFieldExt, Int) [function, functional]
-  syntax TValueList  ::= getTxnField(Int, TxnaFieldExt)      [function, functional]
+  syntax MaybeTValue ::= getTxnField(Int, TxnField)       [function, functional]
+  syntax MaybeTValue ::= getTxnField(Int, TxnaField, Int) [function, functional]
+  syntax TValueList  ::= getTxnField(Int, TxnaField)      [function, functional]
   //-------------------------------------------------------------------------------
   rule [[ getTxnField(I, TxID) => normalize(I) ]]
        <transaction>
@@ -763,7 +763,7 @@ module ALGO-TXN
 
 *Failure*
 ```k
-  rule getTxnField(_, _:TxnaFieldExt) => .TValueList [owise]
+  rule getTxnField(_, _:TxnaField)    => .TValueList [owise]
   rule getTxnField(_, _:TxnField    ) => NoTValue    [owise]
   rule getTxnField(_, _, _          ) => NoTValue    [owise]
 ```
@@ -812,7 +812,7 @@ module ALGO-TXN
 
 
   syntax Bool ::= #isValidForTxnType(TxnField,     Int) [function]
-  syntax Bool ::= #isValidForTxnType(TxnaFieldExt, Int) [function]
+  syntax Bool ::= #isValidForTxnType(TxnaField,    Int) [function]
   // -------------------------------------------------------------
   // all transaction types
   rule #isValidForTxnType(_:TxnHeaderField, I)    => 1 <=Int I andBool I <=Int 6
@@ -828,7 +828,7 @@ module ALGO-TXN
   rule #isValidForTxnType(_:TxnAfrzField  , I)    => I ==Int 5
   // the application call transaction type
   rule #isValidForTxnType(_:TxnApplField  , I)    => I ==Int 6
-  rule #isValidForTxnType(_:TxnaFieldExt  , I)    => I ==Int 6
+  rule #isValidForTxnType(_:TxnaField     , I)    => I ==Int 6
 
 endmodule
 ```

--- a/tests/failing-avm-simulation.list
+++ b/tests/failing-avm-simulation.list
@@ -3,3 +3,10 @@ tests/scenarios/loads-uninitialized.avm-simulation
 tests/scenarios/multi-app.avm-simulation
 tests/scenarios/opcode-budget-test.avm-simulation
 tests/scenarios/uncover.avm-simulation
+tests/scenarios/itxn-appl.avm-simulation
+tests/scenarios/itxn-basic.avm-simulation
+tests/scenarios/itxn-gtxn.avm-simulation
+tests/scenarios/itxn-gload.avm-simulation
+tests/scenarios/itxn-gload2.avm-simulation
+tests/scenarios/itxn-multiple-field-types-set.fail.avm-simulation
+tests/scenarios/itxn-reentrant.fail.avm-simulation

--- a/tests/scenarios/itxn-appl.avm-simulation
+++ b/tests/scenarios/itxn-appl.avm-simulation
@@ -1,0 +1,71 @@
+declareTealSource "itxn-appl.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app 1
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   0           </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Create app 2
+addAppCallTx <txID> 1 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   0           </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app 1 account
+addPaymentTx <txID> 2 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Fund app 2 account
+addPaymentTx <txID> 3 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application2" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app 1, which will call app 2
+addAppCallTx <txID> 4 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   1           </applicationArgs>
+             <foreignApps>       2           </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-basic.avm-simulation
+++ b/tests/scenarios/itxn-basic.avm-simulation
@@ -1,0 +1,48 @@
+declareTealSource "itxn-basic.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app account
+addPaymentTx <txID> 1 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app
+addAppCallTx <txID> 2 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-gload.avm-simulation
+++ b/tests/scenarios/itxn-gload.avm-simulation
@@ -1,0 +1,48 @@
+declareTealSource "itxn-gload.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app account
+addPaymentTx <txID> 1 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app
+addAppCallTx <txID> 2 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-gload2.avm-simulation
+++ b/tests/scenarios/itxn-gload2.avm-simulation
@@ -1,0 +1,71 @@
+declareTealSource "itxn-gload2.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app 1
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Create app 2
+addAppCallTx <txID> 1 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app 1 account
+addPaymentTx <txID> 2 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Fund app 1 account
+addPaymentTx <txID> 3 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application2" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app 1, which will call app 2 twice.
+addAppCallTx <txID> 4 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   1           </applicationArgs>
+             <foreignApps>       2           </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-gtxn.avm-simulation
+++ b/tests/scenarios/itxn-gtxn.avm-simulation
@@ -1,0 +1,71 @@
+declareTealSource "itxn-gtxn.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app 1
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Create app 2
+addAppCallTx <txID> 1 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app 1 account
+addPaymentTx <txID> 2 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Fund app 1 account
+addPaymentTx <txID> 3 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application2" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app 1, which will call app 2 twice.
+addAppCallTx <txID> 4 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   1           </applicationArgs>
+             <foreignApps>       2           </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-gtxn.avm-simulation
+++ b/tests/scenarios/itxn-gtxn.avm-simulation
@@ -45,7 +45,7 @@ addPaymentTx <txID> 2 </txID>
              <receiver> b"application1" </receiver>
              <amount>   500000          </amount>;
 
-// Fund app 1 account
+// Fund app 2 account
 addPaymentTx <txID> 3 </txID>
              <sender>   b"1"            </sender>
              <receiver> b"application2" </receiver>

--- a/tests/scenarios/itxn-multiple-field-types-set.fail.avm-simulation
+++ b/tests/scenarios/itxn-multiple-field-types-set.fail.avm-simulation
@@ -1,0 +1,48 @@
+declareTealSource "itxn-multiple-field-types-set.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app account
+addPaymentTx <txID> 1 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app
+addAppCallTx <txID> 2 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   .TValueList </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/scenarios/itxn-reentrant.fail.avm-simulation
+++ b/tests/scenarios/itxn-reentrant.fail.avm-simulation
@@ -1,0 +1,48 @@
+declareTealSource "itxn-reentrant.teal";
+declareTealSource "clear-basic.teal";
+
+addAccount <address> b"1" </address> <balance> 100000000 </balance>;
+
+#initTxGroup();
+
+// Create app
+addAppCallTx <txID> 0 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     0           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   0           </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+// Fund app account
+addPaymentTx <txID> 1 </txID>
+             <sender>   b"1"            </sender>
+             <receiver> b"application1" </receiver>
+             <amount>   500000          </amount>;
+
+// Call app
+addAppCallTx <txID> 2 </txID>
+             <sender>            b"1"        </sender>
+             <applicationID>     1           </applicationID>
+             <onCompletion>      @ NoOp      </onCompletion>
+             <accounts>          .TValueList </accounts>
+             <applicationArgs>   1           </applicationArgs>
+             <foreignApps>       .TValueList </foreignApps>
+             <foreignAssets>     .TValueList </foreignAssets>
+             <globalNui>         0           </globalNui>
+             <globalNbs>         0           </globalNbs>
+             <localNui>          0           </localNui>
+             <localNbs>          0           </localNbs>
+             <extraProgramPages> 0           </extraProgramPages>
+             <approvalPgmIdx>    0           </approvalPgmIdx>
+             <clearStatePgmIdx>  1           </clearStatePgmIdx>;
+
+#initGlobals(); #evalTxGroup(); .AS

--- a/tests/teal-sources/itxn-appl.teal
+++ b/tests/teal-sources/itxn-appl.teal
@@ -1,0 +1,75 @@
+#pragma version 6
+
+txna ApplicationArgs 0
+btoi
+int 0
+==
+bnz end
+
+txna ApplicationArgs 0
+btoi
+int 1
+==
+bnz lbl1
+
+txna ApplicationArgs 0
+btoi
+int 2
+==
+bnz lbl2
+
+err
+
+b end
+lbl1:
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txna Applications 0
+itxn_field ApplicationID
+
+int 2
+itob
+itxn_field ApplicationArgs
+
+txn Sender
+itxn_field Accounts
+
+int appl
+itxn_field TypeEnum
+
+itxn_submit
+
+txn Sender
+balance
+int 99000100
+==
+assert
+
+b end
+lbl2:
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txna Accounts 1
+itxn_field Receiver
+
+int 100
+itxn_field Amount
+
+int pay
+itxn_field TypeEnum
+
+itxn_submit
+
+b end
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-basic.teal
+++ b/tests/teal-sources/itxn-basic.teal
@@ -1,0 +1,60 @@
+#pragma version 6
+
+txn ApplicationID
+int 0
+==
+bnz end
+
+int 3
+store 5
+int 4
+store 6
+
+global CurrentApplicationID
+global CurrentApplicationAddress
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Sender
+itxn_field Receiver
+
+int 100
+itxn_field Amount
+
+int pay
+itxn_field TypeEnum
+
+itxn_submit
+
+txn Sender
+balance
+int 99500100
+==
+assert
+
+// Check global fields are restored
+global CurrentApplicationAddress
+==
+assert
+
+global CurrentApplicationID
+==
+assert
+
+load 5
+int 3
+==
+assert
+
+load 6
+int 4
+==
+assert
+
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-gload.teal
+++ b/tests/teal-sources/itxn-gload.teal
@@ -1,0 +1,59 @@
+#pragma version 6
+
+txn ApplicationID
+int 0
+==
+bnz handle_init
+
+b handle_run
+
+handle_init:
+
+int 3
+store 5
+
+int 2
+store 7
+
+int 1
+store 9
+
+b end
+handle_run:
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Sender
+itxn_field Receiver
+
+int 100
+itxn_field Amount
+
+int pay
+itxn_field TypeEnum
+
+itxn_submit
+
+gload 0 5
+int 3
+==
+assert
+
+gload 0 7
+int 2
+==
+assert
+
+gload 0 9
+int 1
+==
+assert
+
+b end
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-gload2.teal
+++ b/tests/teal-sources/itxn-gload2.teal
@@ -1,0 +1,86 @@
+#pragma version 6
+
+txn ApplicationID
+int 0
+==
+bnz end
+
+int 1
+txn ApplicationArgs 0
+btoi
+==
+bnz lbl1
+
+int 2
+txn ApplicationArgs 0
+btoi
+==
+bnz lbl2
+
+int 3
+txn ApplicationArgs 0
+btoi
+==
+bnz lbl3
+
+lbl1:
+
+itxn_begin
+
+int appl
+itxn_field TypeEnum
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Applications 0
+itxn_field ApplicationID
+
+int 2
+itob
+itxn_field ApplicationArgs
+
+itxn_next
+
+int appl
+itxn_field TypeEnum
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Applications 0
+itxn_field ApplicationID
+
+int 3
+itob
+itxn_field ApplicationArgs
+
+itxn_submit
+
+b end
+lbl2:
+
+int 123
+store 1
+
+int 456
+store 2
+
+b end
+lbl3:
+
+gload 0 1
+int 123
+==
+assert
+
+gload 0 2
+int 456
+==
+assert
+
+b end
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-gtxn.teal
+++ b/tests/teal-sources/itxn-gtxn.teal
@@ -1,0 +1,65 @@
+#pragma version 6
+
+txn ApplicationID
+int 0
+==
+bnz end
+
+int 1
+txn ApplicationArgs 0
+btoi
+==
+bnz lbl1
+
+int 2
+txn ApplicationArgs 0
+btoi
+==
+bnz lbl2
+
+lbl1:
+
+itxn_begin
+
+int pay
+itxn_field TypeEnum
+
+int 100000
+itxn_field Amount 
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Sender
+itxn_field Receiver
+
+itxn_next
+
+int appl
+itxn_field TypeEnum
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Applications 0
+itxn_field ApplicationID
+
+int 2
+itob
+itxn_field ApplicationArgs
+
+itxn_submit
+
+b end
+lbl2:
+
+gtxn 0 TypeEnum
+int pay
+==
+assert
+
+b end
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-multiple-field-types-set.teal
+++ b/tests/teal-sources/itxn-multiple-field-types-set.teal
@@ -1,0 +1,30 @@
+#pragma version 6
+
+txn ApplicationID
+int 0
+==
+bnz end
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txn Sender
+itxn_field Receiver
+
+int 100
+itxn_field Amount
+
+int pay
+itxn_field TypeEnum
+
+int 0
+itxn_field ApplicationID
+
+itxn_submit
+
+end:
+
+int 1
+return

--- a/tests/teal-sources/itxn-reentrant.teal
+++ b/tests/teal-sources/itxn-reentrant.teal
@@ -1,0 +1,75 @@
+#pragma version 6
+
+txna ApplicationArgs 0
+btoi
+int 0
+==
+bnz end
+
+txna ApplicationArgs 0
+btoi
+int 1
+==
+bnz lbl1
+
+txna ApplicationArgs 0
+btoi
+int 2
+==
+bnz lbl2
+
+err
+
+b end
+lbl1:
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+global CurrentApplicationID
+itxn_field ApplicationID
+
+int 2
+itob
+itxn_field ApplicationArgs
+
+txn Sender
+itxn_field Accounts
+
+int appl
+itxn_field TypeEnum
+
+itxn_submit
+
+txn Sender
+balance
+int 99500100
+==
+assert
+
+b end
+lbl2:
+
+itxn_begin
+
+global CurrentApplicationAddress
+itxn_field Sender
+
+txna Accounts 1
+itxn_field Receiver
+
+int 100
+itxn_field Amount
+
+int pay
+itxn_field TypeEnum
+
+itxn_submit
+
+b end
+end:
+
+int 1
+return


### PR DESCRIPTION
As part of my effort to try to break the work of adding inner transactions into smaller pull requests, this one adds tests that should pass once inner transactions are implemented. Tested here are:
- Simple inner payment transaction
- Payment transaction nested inside an inner app call transaction
- Disallows application calling itself
- Disallows setting incompatible fields for an inner transaction
- Simple inner transaction groups with group scratch and group txn lookups