### PR TITLE
ApplyData support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build
+module-imports-graph.svg

--- a/kavm/src/kavm/adaptors/transaction.py
+++ b/kavm/src/kavm/adaptors/transaction.py
@@ -61,6 +61,12 @@ class KAVMTransaction:
                 'LEASE_CELL': maybe_tvalue(txn.lease),
                 'NOTE_CELL': maybe_tvalue(txn.note),
                 'REKEYTO_CELL': maybe_tvalue(txn.rekey_to),
+                'TXCONFIGASSET_CELL': tvalue(0),
+                'TXAPPLICATIONID_CELL': tvalue(0),
+                'INNERTXNS_CELL': KApply('.List'),
+                'LOGSIZE_CELL': tvalue(0),
+                'LOGDATA_CELL': tvalue_list([]),
+                'TXSCRATCH_CELL': KApply('.Map'),
             }
         )
         type_specific_subst = None
@@ -108,9 +114,6 @@ class KAVMTransaction:
                     'EXTRAPROGRAMPAGES_CELL': maybe_tvalue(txn.extra_pages)
                     if txn.extra_pages is not None
                     else maybe_tvalue(0),
-                    'LOGS_CELL': tvalue_list([]),
-                    'LOGSIZE_CELL': tvalue(0),
-                    'TXSCRATCH_CELL': KApply('.Map'),
                 }
             )
         if type_specific_subst is None:
@@ -134,7 +137,7 @@ class KAVMTransaction:
             }
         )
         empty_service_fields_subst = Subst(
-            {'LOGS_CELL': tvalue_list([]), 'LOGSIZE_CELL': tvalue(0), 'TXSCRATCH_CELL': KApply('.Map')}
+            {'LOGDATA_CELL': tvalue_list([]), 'LOGSIZE_CELL': tvalue(0), 'TXSCRATCH_CELL': KApply('.Map')}
         )
         transaction_cell = fields_subst.apply(empty_transaction_cell)
         empty_fields_subst = Subst({k: maybe_tvalue(None) for k in free_vars(empty_transaction_cell)})

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -413,6 +413,7 @@ Create asset
          <configReserveAddr>   RESERVE_ADDR   </configReserveAddr>
          <configFreezeAddr>    FREEZE_ADDR    </configFreezeAddr>
          <configClawbackAddr>  CLAWB_ADDR     </configClawbackAddr>
+         <txConfigAsset>       _ => ASSET_ID  </txConfigAsset>
          ...
        </transaction>
 
@@ -705,6 +706,7 @@ App create
          <localNui>             LOCAL_INTS          </localNui>
          <localNbs>             LOCAL_BYTES         </localNbs>
          <extraProgramPages>    EXTRA_PAGES         </extraProgramPages>
+         <txApplicationID>      _ => APP_ID         </txApplicationID>
          ...
        </transaction>
        <accountsMap>

--- a/lib/include/kframework/avm/teal/teal-driver.md
+++ b/lib/include/kframework/avm/teal/teal-driver.md
@@ -1373,7 +1373,7 @@ Stateful TEAL Operations
        <currentTx> TX_ID </currentTx>
        <transaction>
          <txID> TX_ID </txID>
-         <logs> LOG => append(MSG, LOG) </logs>
+         <logData> LOG => append(MSG, LOG) </logData>
          <logSize> SIZE => SIZE +Int lengthBytes({MSG}:>Bytes) </logSize>
          ...
        </transaction>
@@ -1386,7 +1386,7 @@ Stateful TEAL Operations
        <currentTx> TX_ID </currentTx>
        <transaction>
          <txID> TX_ID </txID>
-         <logs> LOG </logs>
+         <logData> LOG </logData>
          ...
        </transaction>
     requires size(LOG) >=Int PARAM_MAX_LOG_CALLS

--- a/lib/include/kframework/avm/txn.md
+++ b/lib/include/kframework/avm/txn.md
@@ -81,9 +81,6 @@ past application call transactions in the group. We, thus, maintain a `<finalScr
           <localNbs> NoTValue </localNbs>
         </localStateSchema>
         <extraProgramPages> NoTValue </extraProgramPages>
-        <txScratch>         .Map        </txScratch>
-        <logs>              .TValueList </logs>
-        <logSize>           0:TValue    </logSize>
       </appCallTxFields>
 ```
 
@@ -162,6 +159,7 @@ Transaction Group State Representation
 module ALGO-TXN
   imports TXN-FIELDS
   imports TEAL-TYPES
+  imports LIST
 ```
 
 *Transaction Group Configuration*
@@ -183,12 +181,24 @@ module ALGO-TXN
           <transaction multiplicity="*" type="Map">
             <txID> 0 </txID>
             <txHeader/>
-            <payTxFields/>
-            <appCallTxFields/>
-            <keyRegTxFields/>
-            <assetConfigTxFields/>
-            <assetTransferTxFields/>
-            <assetFreezeTxFields/>
+            <txnTypeSpecificFields>
+              <payTxFields/>
+              <appCallTxFields/>
+              <keyRegTxFields/>
+              <assetConfigTxFields/>
+              <assetTransferTxFields/>
+              <assetFreezeTxFields/>
+            </txnTypeSpecificFields>
+            <applyData>
+              <txScratch>       .Map  </txScratch>
+              <innerTxns>       .List </innerTxns>
+              <txConfigAsset>   0     </txConfigAsset>
+              <txApplicationID> 0     </txApplicationID>
+              <log>
+                <logData> .TValueList </logData>
+                <logSize> 0:TValue    </logSize>
+              </log>
+            </applyData>
           </transaction>
         </transactions>
       </txGroup>
@@ -719,7 +729,7 @@ module ALGO-TXN
        <transaction>
          <txID> I </txID>
          <typeEnum> TYPE  </typeEnum>
-         <logs> _ MSG:TBytes </logs>
+         <logData> _ MSG:TBytes </logData>
          ...
        </transaction>
     requires #isValidForTxnType(Assets, TYPE)
@@ -728,7 +738,7 @@ module ALGO-TXN
        <transaction>
          <txID> I </txID>
          <typeEnum> TYPE  </typeEnum>
-         <logs> MSG:TBytes </logs>
+         <logData> MSG:TBytes </logData>
          ...
        </transaction>
     requires #isValidForTxnType(Assets, TYPE)
@@ -737,7 +747,7 @@ module ALGO-TXN
        <transaction>
          <txID> I </txID>
          <typeEnum> TYPE  </typeEnum>
-         <logs> LOGS </logs>
+         <logData> LOGS </logData>
          ...
        </transaction>
     requires #isValidForTxnType(Assets, TYPE)
@@ -746,7 +756,7 @@ module ALGO-TXN
        <transaction>
          <txID> I </txID>
          <typeEnum> TYPE  </typeEnum>
-         <logs> LOGS </logs>
+         <logData> LOGS </logData>
          ...
        </transaction>
     requires #isValidForTxnType(Assets, TYPE)
@@ -755,7 +765,7 @@ module ALGO-TXN
        <transaction>
          <txID> I </txID>
          <typeEnum> TYPE  </typeEnum>
-         <logs> LOGS </logs>
+         <logData> LOGS </logData>
          ...
        </transaction>
     requires #isValidForTxnType(Assets, TYPE)


### PR DESCRIPTION
This PR consolidates data that is specific to a single transaction and which is modified during the execution of that transaction under a new `<applyData>` cell, which better reflects how these types of transaction fields, etc., are dealt with in go-algorand. The transaction's logs and scratch space, which can be accessed by subsequent transactions, are moved here. In addition, it adds new cells `<txConfigAsset>` and `<txApplicationID>` which store the IDs of the asset or application created by the transaction, respectively, or 0 if neither an app or asset was created, and it adds an `<innerTxns>` cell which is not yet used but will be used to store the application's inner transaction group as it is built (in the case of an `appl` call).