### PR TITLE
Overhaul transaction field access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,19 +378,20 @@ tests/scenarios/%.avm-simulation.unit: tests/scenarios/%.avm-simulation
 ###########################
 ## AVM Symbolic Proof Tests
 ###########################
+avm_prove_specs := $(wildcard tests/specs/*-spec.k) $(wildcard tests/specs/*/*-spec.k)
+avm_prove_specs_failing := $(shell cat tests/failing-symbolic.list)
+avm_prove_specs_passing := $(filter-out $(avm_prove_specs_failing), $(avm_prove_specs))
 
-avm_prove_tests := $(wildcard tests/specs/*-spec.k) $(wildcard tests/specs/*/*-spec.k)
-
-test-avm-semantics-prove: $(avm_prove_tests:=.prove)
+test-avm-semantics-prove: $(avm_prove_specs_passing:=.prove)
 
 tests/specs/%-spec.k.prove: tests/specs/verification-kompiled/timestamp $(KAVM_LIB)/version
 	$(VENV_ACTIVATE) && $(KAVM) prove tests/specs/$*-spec.k --definition tests/specs/verification-kompiled
 
-tests/specs/verification-kompiled/timestamp: tests/specs/verification.k $(VENV_DIR)/pyvenv.cfg $(avm_includes) 
+tests/specs/verification-kompiled/timestamp: tests/specs/verification.k $(VENV_DIR)/pyvenv.cfg $(avm_includes)
 	mkdir -p tests/specs/verification-kompiled
 	$(VENV_ACTIVATE) && $(KAVM) kompile $< --backend haskell --definition-dir tests/specs/verification-kompiled \
                       -I "${KAVM_INCLUDE}/kframework"                                                         \
-											-I "${plugin_include}/kframework"                           
+											-I "${plugin_include}/kframework"
 
 clean-verification:
 	rm -rf tests/specs/verification-kompiled

--- a/kavm/src/kavm/kavm.py
+++ b/kavm/src/kavm/kavm.py
@@ -379,6 +379,7 @@ class KAVM(KRun):
                 'K_CELL': KApply(
                     '#evalTxGroup()_AVM-EXECUTION_AlgorandCommand',
                 ),
+                'TXNINDEXMAP_CELL': KApply('.TxnIndexMapGroupCellMap'),
             }
         )
 

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -71,7 +71,7 @@ and the current configuration is frozen for examination.
   
   // #evalTxGroup
   //---------------------------------------
-  rule <k> #evalTxGroup() => #initTxGroup() ~> #evalNextTx() ...</k>
+  rule <k> #evalTxGroup() => #initTxGroup() ~> #initTxnIndexMap() ~> #evalNextTx() ...</k>
 
   syntax AlgorandCommand ::= #evalNextTx()
 
@@ -123,7 +123,7 @@ the attached stateless TEAL if the transaction is logicsig-signed.
        <currentTx> TXN_ID </currentTx>
        <transaction>
          <txID> TXN_ID </txID>
-         <typeEnum> TXN_TYPE </typeEnum>
+         <typeEnum> _TXN_TYPE </typeEnum>
          <resume> true </resume>
          <sender> SENDER_ADDR </sender>
          ...

--- a/lib/include/kframework/avm/avm-txn-deque.md
+++ b/lib/include/kframework/avm/avm-txn-deque.md
@@ -97,7 +97,7 @@ we will know immediately, since `#pushTxnFront()`/`#pushTxnBack()` would panic.
 ```k
   syntax TxnDequeCommand ::= #getNextTxn()
   rule <k> #getNextTxn() => .K ... </k>
-       <deque> ListItem(TXN_ID) TXNS </deque>
+       <deque> ListItem(TXN_ID) _TXNS </deque>
        <currentTx> _ => TXN_ID </currentTx>
 
 
@@ -107,7 +107,7 @@ we will know immediately, since `#pushTxnFront()`/`#pushTxnBack()` would panic.
   syntax TxnDequeCommand ::= #popTxnFront()
   //-----------------------------------------------
   rule <k> #popTxnFront() => .K ... </k>
-       <deque> ListItem(TXN_ID) TXNS => TXNS </deque>
+       <deque> ListItem(_TXN_ID) TXNS => TXNS </deque>
 
   rule <k> #popTxnFront() => #internalPanic(TXN_DEQUE_ERROR) ... </k>
        <deque> .List </deque>

--- a/lib/include/kframework/avm/blockchain.md
+++ b/lib/include/kframework/avm/blockchain.md
@@ -197,6 +197,7 @@ module ALGO-BLOCKCHAIN
   imports ADDITIONAL-FIELDS
   imports TEAL-SYNTAX
   imports TEAL-TYPES-SYNTAX
+  imports MAP
 
   // Note: An address is the base32 encoding of a {pub key + 4-byte checksum}
   // Note: There are three ways in which an account may be created:
@@ -231,6 +232,12 @@ module ALGO-BLOCKCHAIN
       <nextAppID>    1    </nextAppID>
       <nextTxnID>    0    </nextTxnID>
       <nextGroupID>  1    </nextGroupID>
+      <txnIndexMap>
+        <txnIndexMapGroup multiplicity="*" type="Map">
+          <txnIndexMapGroupKey> "":String </txnIndexMapGroupKey>
+          <txnIndexMapGroupValues> .Map </txnIndexMapGroupValues> // GroupIdx (offset) |-> Transaction ID
+        </txnIndexMapGroup>
+      </txnIndexMap>
     </blockchain>
 ```
 
@@ -795,6 +802,31 @@ references and also to check that a resource is available.
     requires contains(getTxnField(getCurrentTxn(), Assets), A)
 
   rule assetAvailable(_) => false [owise]
+
+```
+
+### Transaction Index Accessors
+
+The transaction index connects a transaction groups ID to the transaction IDs comprising the group
+
+```k
+
+  syntax MaybeTValue ::= getGroupFieldByIdx(String, Int, TxnField) [function]
+  syntax MaybeTValue ::= getGroupFieldByIdx(String, Int, TxnaField, Int) [function]
+
+  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX, FIELD) => getTxnField(TXN_ID, FIELD) ]]
+        <txnIndexMapGroup>
+          <txnIndexMapGroupKey> GROUP_ID </txnIndexMapGroupKey>
+          <txnIndexMapGroupValues> GROUP_INDEX |-> TXN_ID ... </txnIndexMapGroupValues>
+        </txnIndexMapGroup>
+
+  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX, FIELD, FIELD_INDEX) => getTxnField(TXN_ID, FIELD, FIELD_INDEX) ]]
+        <txnIndexMapGroup>
+          <txnIndexMapGroupKey> GROUP_ID </txnIndexMapGroupKey>
+          <txnIndexMapGroupValues> GROUP_INDEX |-> TXN_ID ... </txnIndexMapGroupValues>
+        </txnIndexMapGroup>
+
+  rule getGroupFieldByIdx(_, _, _) => NoTValue [owise]
 
 endmodule
 ```

--- a/lib/include/kframework/avm/itxn.md
+++ b/lib/include/kframework/avm/itxn.md
@@ -419,7 +419,7 @@ module ALGO-ITXN
 
   rule <k> #checkForReentrance(
              <transaction>
-               <txID> TX_ID </txID>
+               <txID> _TX_ID </txID>
                <txnTypeSpecificFields>
                  <appCallTxFields>
                    <applicationID> APP_ID </applicationID>
@@ -427,7 +427,7 @@ module ALGO-ITXN
                  </appCallTxFields>
                </txnTypeSpecificFields>
                ...
-             </transaction>) => . 
+             </transaction>) => .
              ...
        </k>
        <activeApps> AA </activeApps>
@@ -435,7 +435,7 @@ module ALGO-ITXN
 
   rule <k> #checkForReentrance(
              <transaction>
-               <txID> TX_ID </txID>
+               <txID> _TX_ID </txID>
                <txnTypeSpecificFields>
                  <appCallTxFields>
                    <applicationID> APP_ID </applicationID>
@@ -511,7 +511,7 @@ module ALGO-ITXN
          </transaction>) => . ... 
        </k>
 
-  rule <k> #checkItxnFieldsCoherent(<transaction> T </transaction>) => panic(TXN_INVALID) ...</k> [owise]
+  rule <k> #checkItxnFieldsCoherent(<transaction> _T </transaction>) => panic(TXN_INVALID) ...</k> [owise]
 
   syntax KItem ::= #checkItxns(List)
 
@@ -529,7 +529,7 @@ module ALGO-ITXN
   //---------------------------
 
   rule <k> #pushItxns() => (#pushTxnFront(<txID> Int2String(TXN_ID) </txID>) ~> #pushItxns()) ...</k>
-       <innerTransactions> OTHER_ITXNS:List (ListItem(
+       <innerTransactions> _OTHER_ITXNS:List (ListItem(
          <transaction>
            <txID> _ </txID>
            <txHeader>
@@ -550,7 +550,7 @@ module ALGO-ITXN
            </txHeader>
            TXN_BODY
          </transaction>)
-         TXNS
+         _TXNS
        </transactions>
        <nextTxnID> TXN_ID => TXN_ID +Int 1 </nextTxnID>
 

--- a/lib/include/kframework/avm/txn.md
+++ b/lib/include/kframework/avm/txn.md
@@ -207,7 +207,7 @@ module ALGO-TXN
 
 ```k
   syntax String ::= getTxID(TransactionCell) [function, functional]
-  //-------------------------------------------------------------
+  //---------------------------------------------------------------
   rule getTxID(<transaction> <txID> ID </txID> ... </transaction>) => ID
 ```
 
@@ -215,7 +215,7 @@ module ALGO-TXN
 
 ```k
   syntax String ::= getTxnGroupID(String) [function]
-  //---------------------------------------------
+  //------------------------------------------------
   rule [[ getTxnGroupID(TXN_ID) => I ]]
        <transaction> 
          <txID> TXN_ID </txID>
@@ -224,7 +224,7 @@ module ALGO-TXN
        </transaction>
 
   syntax Int ::= getTxnGroupIndex(String) [function]
-  //---------------------------------------------
+  //------------------------------------------------
   rule [[ getTxnGroupIndex(TXN_ID) => I ]]
        <transaction> 
          <txID> TXN_ID </txID>
@@ -232,45 +232,10 @@ module ALGO-TXN
          ...
        </transaction>
 
-//  syntax MaybeTValue ::= getGroupFieldByIdx(String, Int, TxnField) [function]
-  syntax MaybeTValue ::= getGroupFieldByIdx(String, Int) [function]
-//  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX, FIELD) => getTxnField(TX_ID, FIELD) ]]
-
-  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX) => 0 ]]
-//       <transactions>
-       <transaction>
-//         <txID> TX_ID </txID>
-         <groupID> GROUP_ID </groupID>
-         <groupIdx> GROUP_INDEX </groupIdx>
-         ...
-       </transaction>
-//       ...
-//       </transactions>
-
-  syntax MaybeTValue ::= getGroupFieldByIdx(String, Int, TxnaField, Int) [function]
-//  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX, FIELD, INDEX) => getTxnField(TX_ID, FIELD, INDEX) ]]
-  rule [[ getGroupFieldByIdx(GROUP_ID, GROUP_INDEX, FIELD, INDEX) => 0 ]]
-       <transaction>
-//         <txID> TX_ID </txID>
-         <groupID> GROUP_ID </groupID>
-         <groupIdx> GROUP_INDEX </groupIdx>
-//         <groupIdx> _ </groupIdx>
-         ...
-       </transaction>
-
-//  syntax MaybeTValue ::= getGroupTxnField(String, Int, TxnField)       [function, functional]
-  syntax MaybeTValue ::= getGroupTxnField(String, Int)       [function, functional]
-  syntax MaybeTValue ::= getGroupTxnField(String, Int, TxnaField, Int) [function, functional]
-  syntax MaybeTValue ::= getTxnField(String, TxnField)                 [function, functional]
-  syntax MaybeTValue ::= getTxnField(String, TxnaField, Int)           [function, functional]
-  syntax TValueList  ::= getTxnField(String, TxnaField)                [function, functional]
-  //-----------------------------------------------------------------------------------------
-  rule getGroupTxnField(CURRENT_TX_ID, GROUP_INDEX) =>
-//       getGroupFieldByIdx(getTxnGroupID(CURRENT_TX_ID), GROUP_INDEX, FIELD)
-       getGroupFieldByIdx("0", GROUP_INDEX)
-
-  rule getGroupTxnField(CURRENT_TX_ID, GROUP_INDEX, FIELD, INDEX) => 
-       getGroupFieldByIdx(getTxnGroupID(CURRENT_TX_ID), GROUP_INDEX, FIELD, INDEX)
+  syntax MaybeTValue ::= getTxnField(String, TxnField)                 [function]
+  syntax MaybeTValue ::= getTxnField(String, TxnaField, Int)           [function]
+  syntax TValueList  ::= getTxnField(String, TxnaField)                [function]
+  //-----------------------------------------------------------------------------
 
   rule [[ getTxnField(I, TxID) => normalize(I) ]]
        <transaction>
@@ -927,8 +892,8 @@ module ALGO-TXN
   rule _ in_txns( <transactions> .Bag </transactions> ) => false
 
 
-  syntax Bool ::= #isValidForTxnType(TxnField,     Int) [function]
-  syntax Bool ::= #isValidForTxnType(TxnaField,    Int) [function]
+  syntax Bool ::= #isValidForTxnType(TxnField,     Int) [function, functional]
+  syntax Bool ::= #isValidForTxnType(TxnaField,    Int) [function, functional]
   // -------------------------------------------------------------
   // all transaction types
   rule #isValidForTxnType(_:TxnHeaderField  , I)    => 1 <=Int I andBool I <=Int 6
@@ -947,6 +912,9 @@ module ALGO-TXN
   // the application call transaction type
   rule #isValidForTxnType(_:TxnApplField  , I)    => I ==Int 6
   rule #isValidForTxnType(_:TxnaField     , I)    => I ==Int 6
+  // catch-all failure case
+  rule #isValidForTxnType(_:TxnField  , _)    => false [owise]
+  rule #isValidForTxnType(_:TxnaField , _)    => false [owise]
 
 endmodule
 ```

--- a/tests/failing-symbolic.list
+++ b/tests/failing-symbolic.list
@@ -1,0 +1,8 @@
+tests/specs/template-spec.k
+tests/specs/teal-execution-spec.k
+tests/specs/opcodes/opcodes-v2-spec.k
+tests/specs/simple/max-int-spec.k
+tests/specs/simple/max-list-spec.k
+tests/specs/simple/sum-list-spec.k
+tests/specs/simple/sum-to-n-spec.k
+tests/specs/simple/newton-sqrt-spec.k

--- a/tests/specs/opcodes/opcodes-v1-spec.k
+++ b/tests/specs/opcodes/opcodes-v1-spec.k
@@ -419,20 +419,29 @@ module OPCODES-V1-SPEC
 
 // txn f 	1 	heavy_check_mark 	1
   claim <k> txn Sender => . </k>
-        <stack> XS => SENDER : XS </stack>
+        <stack> XS => normalize(SENDER) : XS </stack>
         <stacksize> S => S +Int 1 </stacksize>
         <currentTx> TX_ID </currentTx>
         <transactions>
           <transaction>
             <txID> TX_ID </txID>
-            <groupID> "0" </groupID>
-            <groupIdx> 0 </groupIdx>
+            <groupID> GROUP_ID:String </groupID>
+            <groupIdx> GROUP_INDEX:Int </groupIdx>
             <sender> SENDER:Bytes </sender>
-            <typeEnum> @ appl </typeEnum>
+            <typeEnum> TYPE </typeEnum>
             ...
           </transaction>
+          ...
         </transactions>
-    requires S <Int 1000
+        <txnIndexMap>
+          <txnIndexMapGroup>
+            <txnIndexMapGroupKey> GROUP_ID:String </txnIndexMapGroupKey>
+            <txnIndexMapGroupValues> GROUP_INDEX:Int |-> TX_ID:String </txnIndexMapGroupValues>
+          </txnIndexMapGroup>
+          ...
+        </txnIndexMap>
+    requires S <Int MAX_STACK_DEPTH
+      andBool #isValidForTxnType(Sender, TYPE)
 
 // global f 	1 	heavy_check_mark 	1
   claim <k> global MinBalance => . </k>
@@ -441,28 +450,39 @@ module OPCODES-V1-SPEC
     requires S <Int 1000
 
 // gtxn t f 	1 	heavy_check_mark 	1
-  claim <k> gtxn 0 Sender => . </k>
-        <stack> XS => SENDER : XS </stack>
-        <stacksize> S => S +Int 1 </stacksize>
-        <currentTx> "1" </currentTx>
-        <transactions>
-          <transaction>
-            <txID> "0" </txID>
-            <groupID> "0" </groupID>
-            <groupIdx> 0 </groupIdx>
-            <sender> SENDER:Bytes </sender>
-            <typeEnum> @ appl </typeEnum>
-            ...
-          </transaction>
-          <transaction>
-            <txID> "1" </txID>
-            <groupID> "0" </groupID>
-            <groupIdx> 1 </groupIdx>
-            <typeEnum> @ appl </typeEnum>
-            ...
-          </transaction>
-        </transactions>
-    requires S <Int 1000
+   claim <k> gtxn GROUP_INDEX Sender => . </k>
+         <stack> XS => normalize(SENDER) : XS </stack>
+         <stacksize> S => S +Int 1 </stacksize>
+         <currentTx> CURRENT_TX_ID </currentTx>
+         <transactions>
+           <transaction>
+             <txID> CURRENT_TX_ID </txID>
+             <groupID> GROUP_ID:String </groupID>
+             <groupIdx> CURRENT_GROUP_INDEX:Int </groupIdx>
+             ...
+           </transaction>
+           <transaction>
+             <txID> TARGET_TX_ID </txID>
+             <groupID> GROUP_ID:String </groupID>
+             <groupIdx> GROUP_INDEX:Int </groupIdx>
+             <sender> SENDER:Bytes </sender>
+             <typeEnum> TYPE </typeEnum>
+             ...
+           </transaction>
+           ...
+         </transactions>
+         <txnIndexMap>
+           <txnIndexMapGroup>
+             <txnIndexMapGroupKey> GROUP_ID:String </txnIndexMapGroupKey>
+             <txnIndexMapGroupValues> GROUP_INDEX:Int |-> TARGET_TX_ID:String
+                                      CURRENT_GROUP_INDEX |-> CURRENT_TX_ID:String
+                                      ...
+             </txnIndexMapGroupValues>
+           </txnIndexMapGroup>
+           ...
+         </txnIndexMap>
+     requires S <Int MAX_STACK_DEPTH
+      andBool #isValidForTxnType(Sender, TYPE)
 
 // load i 	1 	heavy_check_mark 	1
   claim <k> load 1 => . </k>

--- a/tests/specs/opcodes/opcodes-v2-spec.k
+++ b/tests/specs/opcodes/opcodes-v2-spec.k
@@ -48,29 +48,6 @@ module OPCODES-V2-SPEC
 //         </transactions>
 //     requires S <Int 1000
 
-  claim <k> loadFromGroup(0, Sender) => 0 </k>
-//        <stack> XS => SENDER : XS </stack>
-//        <currentTx> "2" </currentTx>
-        <transactions>
-          <transaction>
-            <txID> "0" </txID>
-            <groupID> "0" </groupID>
-            <groupIdx> 0 </groupIdx>
-            <sender> SENDER:Bytes </sender>
-//            <typeEnum> @ appl </typeEnum>
-            ...
-          </transaction>
-          <transaction>
-            <txID> TXID </txID>
-            <groupID> "0" </groupID>
-            <groupIdx> 1 </groupIdx>
-//            <typeEnum> @ appl </typeEnum>
-            ...
-          </transaction>
-        </transactions>
-      requires TXID ==K "3"
-//      requires ID =/=K "0"
-
 //   claim <k> gtxna 0 ApplicationArgs 1 => . </k>
 //         <stack> XS => SENDER : XS </stack>
 //         <stacksize> S => S +Int 1 </stacksize>

--- a/tests/specs/teal-execution-spec.k
+++ b/tests/specs/teal-execution-spec.k
@@ -1,11 +1,6 @@
-// Compute maximum of two numbers
-// the program starts with an arbitrary valid stack which must have at least
-// 2 free slots,
-// and an arbitrary scratch that must contain 0 |-> X, 1 |-> Y.
-module MAX-INT-SPEC
+module TEAL-EXECUTION-SPEC
   imports VERIFICATION
 
-  // Compute maximum of two Ints
   claim <k>
          #LoadPgm(
            // load Y and X on stack
@@ -17,33 +12,45 @@ module MAX-INT-SPEC
            // if X > Y then load X on top pf the stack
            load 0
            b END
-           // // otherwise load Y on top of the stack
+           // otherwise load Y on top of the stack
            MAX_Y:
            load 1
-           END:
+           // END:
          , 0)
-         ~> #startExecution()
-         => .
+          // => .
+         ~> #startExecution() => .
         </k>
         <pc> 0 => ?_ </pc>
-        <program> .Map => ?_ </program>
+        <program>
+          .Map =>
+          0 |-> load 0
+          1 |-> load 1
+          2 |-> >
+          3 |-> bz MAX_Y
+          4 |-> load 0
+          5 |-> b END
+          6 |-> MAX_Y:
+          7 |-> load 1
+          8 |-> END:
+        </program>
         <jumped> false </jumped>
-        <mode> stateless </mode>
-        <version> 2 </version>
-        <stack> INITIAL_STACK => ?MAX:Int : INITIAL_STACK </stack>
-        <stacksize> #sizeTStack(INITIAL_STACK) => 1 +Int #sizeTStack(INITIAL_STACK) </stacksize>
-        <scratch> M => M </scratch>
+        <stack> INITIAL_STACK => INITIAL_STACK </stack>
+        <stacksize> #sizeTStack(INITIAL_STACK) => #sizeTStack(INITIAL_STACK) </stacksize>
+        <scratch> SCRATCH => SCRATCH </scratch>
         <labels> LL => ?_ </labels>
         <returncode> 4 => ?RETURN_CODE </returncode>
         <returnstatus>
           "Failure - program is stuck" => ?RETURN_STATUS
         </returnstatus>
+        <globals> _ </globals>
+        <txGroup> _ </txGroup>
+        <blockchain> _ </blockchain>
     requires  notBool (MAX_Y in_labels LL)
       andBool (notBool (END in_labels LL))
       andBool (MAX_Y =/=K END)
 
-      andBool (0 in_keys(M)) andBool (M[0] ==K X:Int)
-      andBool (1 in_keys(M)) andBool (M[1] ==K Y:Int)
+      andBool (0 in_keys(SCRATCH)) andBool (SCRATCH[0] ==K X:Int)
+      andBool (1 in_keys(SCRATCH)) andBool (SCRATCH[1] ==K Y:Int)
 
       andBool #sizeTStack(INITIAL_STACK) +Int 2 <Int MAX_STACK_DEPTH // at least 2 more free slots on stack
     ensures   (?RETURN_CODE =/=Int 3)

--- a/tests/specs/template-spec.k
+++ b/tests/specs/template-spec.k
@@ -1,0 +1,10 @@
+module TEMPLATE-SPEC-SYNTAX
+  imports VERIFICATION
+
+
+endmodule
+
+module TEMPLATE-SPEC
+  imports TEMPLATE-SPEC-SYNTAX
+
+endmodule

--- a/tests/specs/verification.k
+++ b/tests/specs/verification.k
@@ -4,6 +4,15 @@ requires "avm/avm-execution.md"
 module VERIFICATION
   imports AVM-EXECUTION
 
+
+  syntax StepSort ::= MaybeTValue
+// ------------------------------------------------
+
+  syntax KItem ::= runLemma ( StepSort )
+                 | doneLemma( StepSort )
+// --------------------------------------
+  rule runLemma( T ) => doneLemma( T )
+
 ////////////////////////////////////////////////////////////////////////////////
 // Lemmas to support `getbit` opcode specification
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* maintain an index-style cell that maps group ids to their transaction ids
* initialize the index prior to executing the group
* use the index when looking up transaction fields