### PR TITLE
Drop usages of kompilex

### DIFF
--- a/kavm/src/kavm/kompile.py
+++ b/kavm/src/kavm/kompile.py
@@ -131,7 +131,7 @@ def generate_interpreter(
         hook_cpp_files: Optional[List[Path]] = None,
         hook_clang_flags: Optional[List[str]] = None,
     ) -> None:
-        command = ['llvm-kompilex', str(interpreter_object_file), 'main', '--']
+        command = ['llvm-kompile', str(interpreter_object_file), 'main', '--']
 
         command += [str(path) for path in hook_cpp_files] if hook_cpp_files else []
         command += ['-o', str(interpreter_executable_file)]

--- a/tests/hooks/generate-interpreter.sh
+++ b/tests/hooks/generate-interpreter.sh
@@ -31,9 +31,9 @@ kompile $CURDIR/kavm-hooks-tests.k --backend llvm \
         -ccopt -c -ccopt -o -ccopt partial.o
 
 # Compile the C++ code of the blockchain-k-plugin's hooks and the custom hooks and link them into the interpreter
-llvm-kompilex $CURDIR/kavm-hooks-tests-kompiled/partial.o main -- \
-              $PLUGIN_CPP_FILES $KAVM_HOOKS_CPP_FILES             \
-              -I"$KLLVM_INCLUDES"                                 \
-              -I"$LIBFF_INCLUDE" -L"$LIBFF_LIB"                   \
-              $CLANG_FLAGS                                        \
-              -o $CURDIR/kavm-hooks-tests-kompiled/interpreter
+llvm-kompile $CURDIR/kavm-hooks-tests-kompiled/partial.o main -- \
+             $PLUGIN_CPP_FILES $KAVM_HOOKS_CPP_FILES             \
+             -I"$KLLVM_INCLUDES"                                 \
+             -I"$LIBFF_INCLUDE" -L"$LIBFF_LIB"                   \
+             $CLANG_FLAGS                                        \
+             -o $CURDIR/kavm-hooks-tests-kompiled/interpreter


### PR DESCRIPTION
Following https://github.com/runtimeverification/llvm-backend/pull/572, we can drop the x-suffixed script as llvm-kompile has been updated.