### PR TITLE
Add app_params_get

### DIFF
--- a/lib/include/kframework/avm/blockchain.md
+++ b/lib/include/kframework/avm/blockchain.md
@@ -276,6 +276,77 @@ Accessor functions
 
   rule getAccountParamsField(_, _) => NoTValue  [owise]
 
+  syntax MaybeTValue ::= getAppParamsField(AppParamsField, Int) [function, functional]
+  //----------------------------------------------------------------------------------
+  rule [[ getAppParamsField(AppApprovalProgram, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <approvalPgm> X </approvalPgm>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppClearStateProgram, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <clearStatePgm> X </clearStatePgm>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppGlobalNumUint, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <globalNumInts> X </globalNumInts>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppGlobalNumByteSlice, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <globalNumBytes> X </globalNumBytes>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppLocalNumUint, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <localNumInts> X </localNumInts>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppLocalNumByteSlice, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <localNumBytes> X </localNumBytes>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppExtraProgramPages, APP) => X ]]
+       <app>
+         <appID> APP </appID>
+         <extraPages> X </extraPages>
+         ...
+       </app>
+
+  rule [[ getAppParamsField(AppCreator, APP) => X ]]
+       <account>
+         <address> X </address>
+         <appsCreated>
+           <app>
+             <appID> APP </appID>
+             <extraPages> X </extraPages>
+             ...
+           </app>
+           ...
+         </appsCreated>
+         ...
+       </account>
+
+  rule [[ getAppParamsField(AppAddress, APP) => getAppAddress(APP) ]]
+       <accountsMap> AM </accountsMap>
+    requires APP in_apps(<accountsMap> AM </accountsMap>)
+
+  rule getAppParamsField(_, _) => NoTValue [owise]
+
   //TODO: In all accessors below, handle the case when NoTValue is returned
 
   syntax MaybeTValue ::= getAccountField(AccountField, TValue) [function]

--- a/lib/include/kframework/avm/teal/teal-driver.md
+++ b/lib/include/kframework/avm/teal/teal-driver.md
@@ -1941,6 +1941,33 @@ Stateful TEAL Operations
      andBool (isInt(RET) andThenBool {RET}:>Int <Int 0)
 ```
 
+*app_params_get*
+
+```k
+  rule <k> app_params_get FIELD => . ...</k>
+       <stack> APP:Int : XS => 1 : {getAppParamsField(FIELD, APP)}:>TValue : XS </stack>
+       <stacksize> S => S +Int 1 </stacksize>
+    requires isTValue(getAppParamsField(FIELD, APP))
+     andBool S <Int MAX_STACK_DEPTH
+
+  rule <k> app_params_get FIELD => . ...</k>
+       <stack> APP:Int : XS => 0 : 0 : XS </stack>
+       <stacksize> S => S +Int 1 </stacksize>
+    requires notBool(isTValue(getAppParamsField(FIELD, APP)))
+
+  rule <k> app_params_get _ => panic(STACK_OVERFLOW) ...</k>
+       <stacksize> S </stacksize>
+    requires S >=Int MAX_STACK_DEPTH
+
+  rule <k> app_params_get _ => panic(STACK_UNDERFLOW) ...</k>
+       <stacksize> S </stacksize>
+    requires S <Int 1
+
+  rule <k> app_params_get _ => panic(ILL_TYPED_STACK) ...</k>
+       <stack> _:Bytes : _ </stack>
+
+```
+
 ### Access to past transactions in the group
 
 *gaid*

--- a/tests/failing-avm-simulation.list
+++ b/tests/failing-avm-simulation.list
@@ -1,4 +1,3 @@
-tests/scenarios/app-params-get.0.avm-simulation
 tests/scenarios/insufficient-funds.31.avm-simulation
 tests/scenarios/loads-uninitialized.0.avm-simulation
 tests/scenarios/multi-app.0.avm-simulation

--- a/tests/scenarios/app-params-get.0.avm-simulation
+++ b/tests/scenarios/app-params-get.0.avm-simulation
@@ -1,7 +1,7 @@
 declareTealSource "app-params-get.teal";
 declareTealSource "clear-basic.teal";
 
-addAccount <address> b"1" </address> <balance> 10000 </balance>;
+addAccount <address> b"1" </address> <balance> 1000000 </balance>;
 
 #initTxGroup();
 
@@ -10,12 +10,12 @@ addAppCallTx <sender>            b"1"        </sender>
              <onCompletion>      @ OptIn     </onCompletion>
              <accounts>          .TValueList </accounts>
              <applicationArgs>   .TValueList </applicationArgs>
-             <foreignApps>       .TValueList </foreignApps>
+             <foreignApps>       3           </foreignApps>
              <foreignAssets>     .TValueList </foreignAssets>
-             <globalNui>         0           </globalNui>
+             <globalNui>         3           </globalNui>
              <globalNbs>         0           </globalNbs>
              <localNui>          0           </localNui>
-             <localNbs>          0           </localNbs>
+             <localNbs>          4           </localNbs>
              <extraProgramPages> 0           </extraProgramPages>
              <approvalPgmIdx>    0           </approvalPgmIdx>
              <clearStatePgmIdx>  1           </clearStatePgmIdx>;

--- a/tests/teal-sources/app-params-get.teal
+++ b/tests/teal-sources/app-params-get.teal
@@ -1,12 +1,33 @@
 #pragma version 5
 
-app_params_get AppCreator
-
-int 1
+global CurrentApplicationID
+app_params_get AppGlobalNumUint
+assert
+int 3
 ==
 assert
 
-byte 0x1
+global CurrentApplicationID
+app_params_get AppLocalNumByteSlice
+assert
+int 4
+==
+assert
+
+global CurrentApplicationID
+app_params_get AppAddress
+assert
+global CurrentApplicationAddress
+==
+assert
+
+// Test app not existing
+int 3
+app_params_get AppAddress
+int 0
+==
+assert
+int 0
 ==
 assert
 


### PR DESCRIPTION
This PR adds the `app_params_get` opcode, a fairly simple field lookup opcode for information about specific apps. We had known this was missing from the semantics for a while, so I thought it would be good to get it in.