### PR TITLE
Use Python 3.10.6 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
           docker run --name avm-semantics-ci --rm -it --detach --workdir /opt/workspace --user $(id -u):$(id -g) -v ${HOME}:${HOME} -v "$(pwd):/opt/workspace" -v "/etc/passwd:/etc/passwd:ro" -v "/etc/group:/etc/group:ro" runtimeverification/avm-semantics-ci:${KAVM_COMMIT}
       - name: 'Build AVM semantics'
-        run: docker exec -t avm-semantics-ci /bin/bash -c 'make build -j4'
+        run: docker exec -t avm-semantics-ci /bin/bash -c 'make build'
       - name: 'Test kavm kast'
         run: |
           docker exec -t avm-semantics-ci /bin/bash -c 'make -j4 test-kavm-kast-teal'

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ RUN curl -L https://github.com/github/hub/releases/download/v2.14.0/hub-linux-am
 RUN cd /home/user && tar xzf hub.tgz
 
 ENV PATH=/home/user/hub-linux-amd64-2.14.0/bin:$PATH
-RUN pyenv version
-RUN python --version
 
 RUN    git config --global user.email 'admin@runtimeverification.com' \
     && git config --global user.name  'RV Jenkins'                    \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,31 @@ RUN    apt-get update            \
             libyaml-dev          \
             maven                \
             pkg-config           \
-            python3              \
-            python3-pip          \
             zlib1g-dev
 
-RUN pip3 install virtualenv
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
+
+RUN curl -sSL https://get.haskellstack.org/ | sh
+
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr python3 - && poetry --version
+
+USER user:user
+WORKDIR /home/user
+
+# Set-up pyenv
+ENV PYTHON_VERSION 3.10.6
+ENV PYENV_ROOT /home/user/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Install pyenv
+RUN set -ex \
+    && curl https://pyenv.run | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd z3                                                         \
@@ -33,21 +53,12 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd ../..                                                      \
     && rm -rf z3
 
-RUN curl -sSL https://get.haskellstack.org/ | sh
-
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr python3 - && poetry --version
-
-ARG USER_ID=1000
-ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
-
-USER user:user
-WORKDIR /home/user
-
 RUN curl -L https://github.com/github/hub/releases/download/v2.14.0/hub-linux-amd64-2.14.0.tgz -o /home/user/hub.tgz
 RUN cd /home/user && tar xzf hub.tgz
 
 ENV PATH=/home/user/hub-linux-amd64-2.14.0/bin:$PATH
+RUN pyenv version
+RUN python --version
 
 RUN    git config --global user.email 'admin@runtimeverification.com' \
     && git config --global user.name  'RV Jenkins'                    \

--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,9 @@ build-kavm-hooks-tests: $(hook_includes) plugin-deps
 #######
 ## kavm
 #######
+check-codestyle-kavm:
+	$(MAKE) check -C $(PY_KAVM_DIR)
+
 ## * kavm CLI tests
 test-kavm: test-kavm-kast module-imports-graph
 

--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,9 @@ VENV_DIR       := $(BUILD_DIR)/venv
 VENV_ACTIVATE  := . $(VENV_DIR)/bin/activate
 
 $(VENV_DIR)/pyvenv.cfg:
-	   virtualenv $(VENV_DIR) \
-	&& $(VENV_ACTIVATE)       \
-	&& pip install --editable $(PY_KAVM_DIR)
+	   python -m venv $(VENV_DIR) \
+           && $(VENV_ACTIVATE)        \
+           && pip install --editable $(PY_KAVM_DIR)
 
 venv: $(VENV_DIR)/pyvenv.cfg
 	@echo $(VENV_ACTIVATE)

--- a/kavm/Makefile
+++ b/kavm/Makefile
@@ -13,6 +13,8 @@ clean:
 
 THREADS := $(if $(THREADS),$(THREADS),1)
 PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.10.6)
+POETRY_RUN := poetry run
+PYTEST_ARGS := -n $(THREADS)
 
 build:
 	pyenv local $(PYTHON_VERSION) && poetry build
@@ -20,10 +22,6 @@ build:
 poetry-install:
 	pyenv local $(PYTHON_VERSION) && poetry install
 
-POETRY_RUN := poetry run
-THREADS := $(if $(THREADS),$(THREADS),1)
-
-PYTEST_ARGS := -n $(THREADS)
 
 # Tests
 

--- a/kavm/Makefile
+++ b/kavm/Makefile
@@ -11,11 +11,14 @@ clean:
 	rm -rf dist .mypy_cache
 	find -type d -name __pycache__ -prune -exec rm -rf {} \;
 
+THREADS := $(if $(THREADS),$(THREADS),1)
+PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.10.6)
+
 build:
-	poetry build
+	pyenv local $(PYTHON_VERSION) && poetry build
 
 poetry-install:
-	poetry install
+	pyenv local $(PYTHON_VERSION) && poetry install
 
 POETRY_RUN := poetry run
 THREADS := $(if $(THREADS),$(THREADS),1)


### PR DESCRIPTION
The current version of PyTeal requires Python 3.10, while so far we've been using Python 3.8.

This PR uses `pyenv` to install and use Python 3.10.6 in the Docker image.