### PR TITLE
Drop z3 from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,22 +18,30 @@ RUN    apt-get update            \
             libyaml-dev          \
             maven                \
             pkg-config           \
-            python3              \
-            python3-pip          \
             zlib1g-dev
-
-RUN pip3 install virtualenv
-
-RUN curl -sSL https://get.haskellstack.org/ | sh
-
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr python3 - && poetry --version
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 
+RUN curl -sSL https://get.haskellstack.org/ | sh
+
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr python3 - && poetry --version
+
 USER user:user
 WORKDIR /home/user
+
+# Set-up pyenv
+ENV PYTHON_VERSION 3.10.6
+ENV PYENV_ROOT /home/user/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Install pyenv
+RUN set -ex \
+    && curl https://pyenv.run | bash \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
 
 RUN curl -L https://github.com/github/hub/releases/download/v2.14.0/hub-linux-amd64-2.14.0.tgz -o /home/user/hub.tgz
 RUN cd /home/user && tar xzf hub.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,6 @@ RUN    apt-get update            \
 
 RUN pip3 install virtualenv
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
-    && cd z3                                                         \
-    && python3 scripts/mk_make.py                                    \
-    && cd build                                                      \
-    && make -j8                                                      \
-    && make install                                                  \
-    && cd ../..                                                      \
-    && rm -rf z3
-
 RUN curl -sSL https://get.haskellstack.org/ | sh
 
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr python3 - && poetry --version


### PR DESCRIPTION
The base image's Dockerfile already build and installs the proper version of z3 reuired by K. No need to install it again.