### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,0 +1,54 @@
+name: 'Master Push'
+on:
+  push:
+    branches:
+      # - master
+      - sam/nix-flake
+
+jobs:
+  nix-flake-release:
+    name: 'Nix flake release'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: ubuntu-latest
+          - runner: macos-12
+            os: macos-12
+          - runner: MacM1
+            os: self-macos-12
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+
+      - name: 'Upgrade bash'
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: brew install bash
+
+      - name: 'Install Nix/Cachix'
+        if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      - if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/cachix-action@v10
+        with:
+          name: k-framework
+          signingKey: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+          skipPush: true
+
+      - name: 'Build and cache kavm'
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+        with:
+          packages: jq
+          script: |
+            kavm=$(nix build .#kavm --json | jq -r '.[].outputs | to_entries[].value')
+            drv=$(nix-store --query --deriver ${kavm})
+            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-nix:
+    name: 'Nix / Build'
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: ubuntu-latest
+          - runner: macos-12
+            os: macos-12
+          - runner: MacM1
+            os: self-macos-12
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+      - name: 'Install Nix/Cachix'
+        uses: cachix/install-nix-action@v18
+        with:
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
+          extra_nix_config: |
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      - uses: cachix/cachix-action@v10
+        with:
+          name: k-framework
+          signingKey: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+          skipPush: true
+      - name: 'Build via Nix'
+        run: nix build .#kavm
   test-pr:
     name: 'Test PR'
     runs-on: [self-hosted, linux, normal]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
             os: ubuntu-latest
           - runner: macos-12
             os: macos-12
-          - runner: MacM1
-            os: self-macos-12
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'

--- a/flake.lock
+++ b/flake.lock
@@ -878,14 +878,18 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1666957596,
-        "narHash": "sha256-kX2xIePA94qhH2mNmzt+c+BBP2sUBUevXfDCpkzjlmc=",
-        "path": "/home/sam/git/pyk",
-        "type": "path"
+        "lastModified": 1666958302,
+        "narHash": "sha256-A3+XYM/oeUaX03ZTlH3FNY+wsrmq36yhFdvYolNGsd8=",
+        "owner": "runtimeverification",
+        "repo": "pyk",
+        "rev": "af9530cb219250c7ab9ef1114a70ac8c9b7a5205",
+        "type": "github"
       },
       "original": {
-        "path": "/home/sam/git/pyk",
-        "type": "path"
+        "owner": "runtimeverification",
+        "ref": "af9530c",
+        "repo": "pyk",
+        "type": "github"
       }
     },
     "pypi-deps-db": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,1089 @@
+{
+  "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "ate-pairing": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1499347915,
+        "narHash": "sha256-IMfWgKkkX7UcUaOPtGRcYD8MdVEP5Z9JOOSJ4+P07G8=",
+        "owner": "herumi",
+        "repo": "ate-pairing",
+        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "herumi",
+        "repo": "ate-pairing",
+        "rev": "e69890125746cdaf25b5b51227d96678f76479fe",
+        "type": "github"
+      }
+    },
+    "blockchain-k-plugin": {
+      "inputs": {
+        "ate-pairing": "ate-pairing",
+        "cpp-httplib": "cpp-httplib",
+        "cryptopp": "cryptopp",
+        "flake-utils": [
+          "k-framework",
+          "flake-utils"
+        ],
+        "libff": "libff",
+        "nixpkgs": [
+          "k-framework",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "xbyak": "xbyak"
+      },
+      "locked": {
+        "lastModified": 1656687523,
+        "narHash": "sha256-XapLiUTC0bA764+Mq82QINTO0NJpTDoKveeBtQ/PgVY=",
+        "owner": "runtimeverification",
+        "repo": "blockchain-k-plugin",
+        "rev": "8fdc74e3caf254aa3952393dbb0368d2c98c321a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "blockchain-k-plugin",
+        "rev": "8fdc74e3caf254aa3952393dbb0368d2c98c321a",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cpp-httplib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1595279716,
+        "narHash": "sha256-cZW/iEwlaB4UQ0OQLNqboY9addncIM/OsxxPzqmATmE=",
+        "owner": "yhirose",
+        "repo": "cpp-httplib",
+        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yhirose",
+        "repo": "cpp-httplib",
+        "rev": "72ce293fed9f9335e92c95ab7d085feed18c0ee8",
+        "type": "github"
+      }
+    },
+    "cryptopp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1632484127,
+        "narHash": "sha256-a3TYaK34WvKEXN7LKAfGwQ3ZL6a3k/zMZyyVfnkQqO4=",
+        "owner": "weidai11",
+        "repo": "cryptopp",
+        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
+        "type": "github"
+      },
+      "original": {
+        "owner": "weidai11",
+        "repo": "cryptopp",
+        "rev": "69bf6b53052b59ccb57ce068ce741988ae087317",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654823898,
+        "narHash": "sha256-75XxIB6XOIxmhxyX7SJ6sA1WAg4xh6GJO0KjTvi3+LQ=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f0a8972ca2724c5ac5cd829050b2b3c02a04ba41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-backend": {
+      "inputs": {
+        "haskell-nix": "haskell-nix",
+        "mach-nix": "mach-nix",
+        "nixpkgs": [
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs22_05": "nixpkgs22_05",
+        "z3-src": "z3-src"
+      },
+      "locked": {
+        "lastModified": 1665459077,
+        "narHash": "sha256-uNSLNruZwM+DW53MZOaDSUtzMB2sas4WggUb+wB01bg=",
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "rev": "4c3c436336c861e9b2ab094e99b4ab086d772fbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "haskell-backend",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-utils": "flake-utils_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "nix-tools": "nix-tools",
+        "nixpkgs": [
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1654824048,
+        "narHash": "sha256-qSjPdxa+WdDgG1W7GhGEtS6gH8UqchB0KrpE6hlOFnU=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "75b545a7937db878e4d301ecb171f6ac9040bb91",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "k-framework",
+          "haskell-backend",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "immer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634324349,
+        "narHash": "sha256-1OicqmyM3Rcrs/jkRMip2pXITQnVDRrHbQbEpZZ4nnU=",
+        "owner": "runtimeverification",
+        "repo": "immer",
+        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "immer",
+        "rev": "198c2ae260d49ef1800a2fe4433e07d7dec20059",
+        "type": "github"
+      }
+    },
+    "k-framework": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "haskell-backend": "haskell-backend",
+        "llvm-backend": "llvm-backend",
+        "mavenix": "mavenix_2",
+        "nixpkgs": "nixpkgs_5",
+        "poetry2nix": "poetry2nix",
+        "rv-utils": "rv-utils"
+      },
+      "locked": {
+        "lastModified": 1666904578,
+        "narHash": "sha256-tAky8TXn5JxC6ZlTna09PTpdLIyiT1PjYba2QoclSzw=",
+        "owner": "runtimeverification",
+        "repo": "k",
+        "rev": "fc61802320bf64d4e0b1f2462e7e91ea2d3296bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "k",
+        "type": "github"
+      }
+    },
+    "libff": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588032522,
+        "narHash": "sha256-I0kH2XLvHDSrdL/o4i6XozWQJV0UDv9zH6+sWS0UQHg=",
+        "owner": "scipr-lab",
+        "repo": "libff",
+        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
+        "type": "github"
+      },
+      "original": {
+        "owner": "scipr-lab",
+        "repo": "libff",
+        "rev": "5835b8c59d4029249645cf551f417608c48f2770",
+        "type": "github"
+      }
+    },
+    "llvm-backend": {
+      "inputs": {
+        "immer-src": "immer-src",
+        "mavenix": "mavenix",
+        "nixpkgs": [
+          "k-framework",
+          "haskell-backend",
+          "nixpkgs"
+        ],
+        "pybind11-src": "pybind11-src",
+        "rapidjson-src": "rapidjson-src",
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1665753882,
+        "narHash": "sha256-qaC+kEi/AKjI60CdzbtjKTZEGjljBz8Skd4x1m1ho6E=",
+        "owner": "runtimeverification",
+        "repo": "llvm-backend",
+        "rev": "94e8f4b1052200a10d66c4f2c5d6a7b43bfeb913",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "llvm-backend",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1657089034,
+        "narHash": "sha256-qSjk1iOi14ijAOP6QuGfE3fvy08aVxsgus+ArwgiyuU=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "51caf584f26acdfaa51bbf7ee1ffa365aea7bc64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "mavenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1643802645,
+        "narHash": "sha256-BynM25iwp/l3FyrcHqiNJdDxvN6IxSM3/zkFR6PD3B0=",
+        "owner": "nix-community",
+        "repo": "mavenix",
+        "rev": "ce9ddfd7f361190e8e8dcfaf6b8282eebbb3c7cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "mavenix",
+        "type": "github"
+      }
+    },
+    "mavenix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4",
+        "utils": "utils_3"
+      },
+      "locked": {
+        "lastModified": 1656435814,
+        "narHash": "sha256-Gx4QoWB9eI437/66iqTr6AUjxGgN6WslqrQ57s+sL6A=",
+        "owner": "goodlyrottenapple",
+        "repo": "mavenix",
+        "rev": "0cbd57b2494d52909b27f57d03580acc66bf0298",
+        "type": "github"
+      },
+      "original": {
+        "owner": "goodlyrottenapple",
+        "repo": "mavenix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-tools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs22_05": {
+      "locked": {
+        "lastModified": 1662099760,
+        "narHash": "sha256-MdZLCTJPeHi/9fg6R9fiunyDwP3XHJqDd51zWWz9px0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "67e45078141102f45eff1589a831aeaa3182b41e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1621552131,
+        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1621552131,
+        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1665927063,
+        "narHash": "sha256-2oImLqwQqVOQhTXsGUahqrYpe+Pufq+8XTsceYwBfJs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8de8b98839d1f20089582cfe1a81207258fcc1f1",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1665996180,
+        "narHash": "sha256-rJJm4Uv8Gjo2DEYtX+4EwZZyfeMfp1R3l+Tr60ZCt1U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6fa94e7ea706caffd31f545504aaf13448fbbd52",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1666028767,
+        "narHash": "sha256-OAR2Oo69gyqsaYuC56C7GvjnKPb7A+gRd3oje3sa3p4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "223c8b1644e5621e5a7a5b5aae1fafa47d1b0cad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1665455310,
+        "narHash": "sha256-gEG1UiKz65SNWDU1NJmxLneo+kn7WjxrfucSk1zhU6o=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d62ba59f1e28c382665c57203a4b9ad11fd7f449",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "poetry2nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1665455310,
+        "narHash": "sha256-gEG1UiKz65SNWDU1NJmxLneo+kn7WjxrfucSk1zhU6o=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "d62ba59f1e28c382665c57203a4b9ad11fd7f449",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "1.35.0",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pybind11-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657936673,
+        "narHash": "sha256-/X8DZPFsNrKGbhjZ1GFOj17/NU6p4R+saCW3pLKVNeA=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "0ba639d6177659c5dc2955ac06ad7b5b0d22e05c",
+        "type": "github"
+      }
+    },
+    "pyk": {
+      "inputs": {
+        "flake-utils": [
+          "k-framework",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "k-framework",
+          "nixpkgs"
+        ],
+        "poetry2nix": "poetry2nix_2"
+      },
+      "locked": {
+        "lastModified": 1666957596,
+        "narHash": "sha256-kX2xIePA94qhH2mNmzt+c+BBP2sUBUevXfDCpkzjlmc=",
+        "path": "/home/sam/git/pyk",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/sam/git/pyk",
+        "type": "path"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643877077,
+        "narHash": "sha256-jv8pIvRFTP919GybOxXE5TfOkrjTbdo9QiCO1TD3ZaY=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "da53397f0b782b0b18deb72ef8e0fb5aa7c98aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "rapidjson-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1472111945,
+        "narHash": "sha256-SxUXSOQDZ0/3zlFI4R84J56/1fkw2jhge4mexNF6Pco=",
+        "owner": "Tencent",
+        "repo": "rapidjson",
+        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Tencent",
+        "repo": "rapidjson",
+        "rev": "f54b0e47a08782a6131cc3d60f94d038fa6e0a51",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "blockchain-k-plugin": "blockchain-k-plugin",
+        "flake-utils": [
+          "k-framework",
+          "flake-utils"
+        ],
+        "k-framework": "k-framework",
+        "nixpkgs": [
+          "k-framework",
+          "nixpkgs"
+        ],
+        "poetry2nix": [
+          "pyk",
+          "poetry2nix"
+        ],
+        "pyk": "pyk",
+        "rv-utils": "rv-utils_2"
+      }
+    },
+    "rv-utils": {
+      "locked": {
+        "lastModified": 1659349707,
+        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "type": "github"
+      }
+    },
+    "rv-utils_2": {
+      "locked": {
+        "lastModified": 1659349707,
+        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "type": "github"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1502408521,
+        "narHash": "sha256-PyqNZGER9VypH35S/aU4EBeepieI3BGXrYsJ141os24=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f",
+        "type": "github"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654823991,
+        "narHash": "sha256-uaa/v4SnWBCihr9jOrjJsJF5Ifteom2JEteVWCz0j2M=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "98529daae8cf6c38955b49f71f4538e270d8c8af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_3": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "xbyak": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1518572786,
+        "narHash": "sha256-jqDSNDcqK7010ig941hrJFkv1X7MbgXmhPOOE9wHmho=",
+        "owner": "herumi",
+        "repo": "xbyak",
+        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "herumi",
+        "repo": "xbyak",
+        "rev": "f0a8f7faa27121f28186c2a7f4222a9fc66c283d",
+        "type": "github"
+      }
+    },
+    "z3-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647807944,
+        "narHash": "sha256-hXlwaLsrMKm0rPAhRtynCjdhkeXIYzfNcjS04sHHfHY=",
+        "owner": "Z3Prover",
+        "repo": "z3",
+        "rev": "f1806d32d6f21fd4df7a08719abbc1f6493d9dc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Z3Prover",
+        "ref": "z3-4.8.15",
+        "repo": "z3",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -878,16 +878,16 @@
         "poetry2nix": "poetry2nix_2"
       },
       "locked": {
-        "lastModified": 1666958302,
+        "lastModified": 1666960531,
         "narHash": "sha256-A3+XYM/oeUaX03ZTlH3FNY+wsrmq36yhFdvYolNGsd8=",
         "owner": "runtimeverification",
         "repo": "pyk",
-        "rev": "af9530cb219250c7ab9ef1114a70ac8c9b7a5205",
+        "rev": "ea49f3dc3cbec205417534e0b4089c6b07faef42",
         "type": "github"
       },
       "original": {
         "owner": "runtimeverification",
-        "ref": "af9530c",
+        "ref": "v0.1.35",
         "repo": "pyk",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,7 @@
       "github:runtimeverification/blockchain-k-plugin/8fdc74e3caf254aa3952393dbb0368d2c98c321a";
     blockchain-k-plugin.inputs.flake-utils.follows = "k-framework/flake-utils";
     blockchain-k-plugin.inputs.nixpkgs.follows = "k-framework/nixpkgs";
-    # pyk.url = "github:runtimeverification/pyk/v0.1.30";
-    pyk.url = "path:/home/sam/git/pyk";
+    pyk.url = "github:runtimeverification/pyk/af9530c";
     pyk.inputs.flake-utils.follows = "k-framework/flake-utils";
     pyk.inputs.nixpkgs.follows = "k-framework/nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,7 @@
               openssl.dev
               procps
             ];
+            nativeBuildInputs = [ prev.makeWrapper ];
 
             src = prev.nix-gitignore.gitignoreSourcePure [
               ./.gitignore
@@ -127,7 +128,9 @@
               mv .build/usr/* $out/
               ln -s ${k} $out/lib/kavm/kframework
               mkdir $out/bin
-              ln -s ${kavm-bin}/bin/kavm $out/bin/
+              makeWrapper ${kavm-bin}/bin/kavm $out/bin/kavm \
+                --set KAVM_DEFINITION_DIR $out/lib/kavm/avm-llvm/avm-execution-kompiled \
+                --set KAVM_LIB $out/lib/kavm
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       "github:runtimeverification/blockchain-k-plugin/8fdc74e3caf254aa3952393dbb0368d2c98c321a";
     blockchain-k-plugin.inputs.flake-utils.follows = "k-framework/flake-utils";
     blockchain-k-plugin.inputs.nixpkgs.follows = "k-framework/nixpkgs";
-    pyk.url = "github:runtimeverification/pyk/af9530c";
+    pyk.url = "github:runtimeverification/pyk/v0.1.35";
     pyk.inputs.flake-utils.follows = "k-framework/flake-utils";
     pyk.inputs.nixpkgs.follows = "k-framework/nixpkgs";
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,10 @@
             dontUseCmakeConfigure = true;
 
             buildPhase = ''
-              make SHELL=${prev.bash}/bin/bash plugin-deps
+              make \
+                APPLE_SILICON=${if prev.stdenv.isAarch64 && prev.stdenv.isDarwin then "true" else "false"} \
+                SHELL=$SHELL \
+                plugin-deps
             '';
 
             enableParallelBuilding = true;
@@ -113,7 +116,10 @@
               mkdir -p .build/usr/
               cp -r ${kavm-deps}/* .build/usr/
               chmod -R u+w .build/
-              make SHELL=${prev.bash}/bin/bash VENV_ACTIVATE=true build
+              make \
+                SHELL=$SHELL VENV_ACTIVATE=true \
+                ${if prev.stdenv.isDarwin then "UNAME_S=" else ""} \
+                build
             '';
 
             installPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,200 @@
+{
+  description = "A flake for the KAVM Semantics";
+
+  inputs = {
+    k-framework.url = "github:runtimeverification/k";
+    nixpkgs.follows = "k-framework/nixpkgs";
+    flake-utils.follows = "k-framework/flake-utils";
+    rv-utils.url = "github:runtimeverification/rv-nix-tools";
+    poetry2nix.follows = "pyk/poetry2nix";
+    blockchain-k-plugin.url =
+      "github:runtimeverification/blockchain-k-plugin/8fdc74e3caf254aa3952393dbb0368d2c98c321a";
+    blockchain-k-plugin.inputs.flake-utils.follows = "k-framework/flake-utils";
+    blockchain-k-plugin.inputs.nixpkgs.follows = "k-framework/nixpkgs";
+    # pyk.url = "github:runtimeverification/pyk/v0.1.30";
+    pyk.url = "path:/home/sam/git/pyk";
+    pyk.inputs.flake-utils.follows = "k-framework/flake-utils";
+    pyk.inputs.nixpkgs.follows = "k-framework/nixpkgs";
+
+  };
+  outputs = { self, k-framework, nixpkgs, flake-utils, poetry2nix
+    , blockchain-k-plugin, rv-utils, pyk }:
+    let
+      buildInputs = pkgs: k:
+        with pkgs; [
+          autoconf
+          automake
+          cmake
+          clang
+          cryptopp.dev
+          gmp
+          openssl.dev
+          pkg-config
+          procps
+          libtool
+        ];
+
+      overlay = final: prev:
+        let
+          kavm-deps = prev.stdenv.mkDerivation {
+            pname = "kavm-deps";
+            version = self.rev or "dirty";
+            buildInputs = with prev; [
+              autoconf
+              automake
+              cmake
+              clang
+              cryptopp.dev
+              gmp
+              openssl.dev
+              pkg-config
+              procps
+              libtool
+            ];
+
+            src = prev.stdenv.mkDerivation {
+              name = "kavm-deps-${self.rev or "dirty"}-src";
+              phases = [ "installPhase" ];
+              src = ./Makefile;
+              installPhase = ''
+                mkdir $out
+                cp $src $out/Makefile
+                chmod -R u+w $out
+                mkdir -p $out/deps/plugin
+                cp -rv ${prev.blockchain-k-plugin-src}/* $out/deps/plugin/
+              '';
+            };
+
+            dontUseCmakeConfigure = true;
+
+            buildPhase = ''
+              make SHELL=${prev.bash}/bin/bash plugin-deps
+            '';
+
+            enableParallelBuilding = true;
+
+            installPhase = ''
+              mkdir -p $out
+              mv .build/usr/* $out/
+            '';
+          };
+        in {
+          inherit kavm-deps;
+          kavm = let
+            k = k-framework.packages.${prev.system}.k;
+            kavm-bin = prev.poetry2nix.mkPoetryApplication {
+              python = prev.python310;
+              projectDir = ./kavm;
+              overrides = prev.poetry2nix.overrides.withDefaults
+                (finalPython: prevPython: { pyk = prev.python310Packages.pyk; });
+              groups = [ ];
+              # We remove `"dev"` from `checkGroups`, so that poetry2nix does not try to resolve dev dependencies.
+              checkGroups = [ ];
+              propagatedBuildInputs = [ k prev.llvm-backend ];
+            };
+          in prev.stdenv.mkDerivation {
+            pname = "kavm";
+            version = self.rev or "dirty";
+            buildInputs = with prev; [
+              kavm-bin
+              cryptopp.dev
+              curl.dev
+              secp256k1
+              msgpack
+              openssl.dev
+              procps
+            ];
+
+            src = prev.nix-gitignore.gitignoreSourcePure [
+              ./.gitignore
+              ".github/"
+              "result*"
+              "*.nix"
+              "deps/"
+              "kavm/"
+            ] ./.;
+
+            dontUseCmakeConfigure = true;
+
+            postPatch = ''
+              substituteInPlace ./Makefile \
+                --replace '$(MAKE) build -C $(PY_KAVM_DIR)' 'echo "Skip py-kavm"' \
+                --replace 'py-kavm $(VENV_DIR)/pyvenv.cfg' ' ' \
+                --replace 'plugin-deps $(hook_includes)' '$(hook_includes)'
+            '';
+
+            enableParallelBuilding = true;
+
+            buildPhase = ''
+              mkdir -p .build/usr/
+              cp -r ${kavm-deps}/* .build/usr/
+              chmod -R u+w .build/
+              make SHELL=${prev.bash}/bin/bash VENV_ACTIVATE=true build
+            '';
+
+            installPhase = ''
+              mkdir -p $out
+              mv .build/usr/* $out/
+              ln -s ${k} $out/lib/kavm/kframework
+              mkdir $out/bin
+              ln -s ${kavm-bin}/bin/kavm $out/bin/
+            '';
+
+          };
+
+        };
+    in flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: { llvm-backend-release = false; })
+            k-framework.overlay
+            blockchain-k-plugin.overlay
+            poetry2nix.overlay
+            pyk.overlay
+            overlay
+          ];
+        };
+      in {
+        packages.default = pkgs.kavm;
+
+        apps = {
+          compare-profiles = flake-utils.lib.mkApp {
+            drv = pkgs.stdenv.mkDerivation {
+              name = "compare-profiles";
+              src = ./package/nix;
+              installPhase = ''
+                mkdir -p $out/bin
+                cp profile.py $out/bin/compare-profiles
+              '';
+            };
+          };
+        };
+
+        packages = {
+          inherit (pkgs) kavm kavm-deps;
+
+          check-submodules = rv-utils.lib.check-submodules pkgs {
+            inherit k-framework blockchain-k-plugin;
+          };
+
+          update-from-submodules =
+            rv-utils.lib.update-from-submodules pkgs ./flake.lock {
+              k-framework.submodule = "deps/k";
+              blockchain-k-plugin.submodule = "deps/plugin";
+            };
+        };
+      }) // {
+        overlays.default = nixpkgs.lib.composeManyExtensions [
+          k-framework.overlay
+          blockchain-k-plugin.overlay
+          overlay
+        ];
+      };
+}

--- a/kavm/pyproject.toml
+++ b/kavm/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.10"
 py-algorand-sdk = "1.15.0"
 pyk = { git = "https://github.com/runtimeverification/pyk.git", tag="v0.1.30" }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 autoflake = "*"
 black = "*"
 flake8 = "*"


### PR DESCRIPTION
This PR adds preliminary support for building with nix, towards supporting installs via `kup` ( #147). To test, run:

```
nix shell .
```

inside the repo and `kavm` should build and be available on the PATH... stuff might still be broken when trying to run kavm tho...