### PR TITLE
Add simple specs to failing file

### DIFF
--- a/tests/failing-symbolic.list
+++ b/tests/failing-symbolic.list
@@ -1,2 +1,5 @@
+tests/specs/simple/max-int-spec.k
 tests/specs/simple/max-list-spec.k
+tests/specs/simple/newton-sqrt-spec.k
+tests/specs/simple/sum-list-spec.k
 tests/specs/simple/sum-to-n-spec.k


### PR DESCRIPTION
The tests in `tests/specs/simple/` were sometimes failing in CI for reasons that we were unable to figure out, possibly nondeterministically, when z3 fails to solve a constraint. This PR disables the rest of them for now.