### PR TITLE
Build system changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG K_DISTRO=focal
+ARG K_DISTRO=jammy
 ARG K_VERSION
 FROM runtimeverificationinc/kframework-k:ubuntu-${K_DISTRO}-${K_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,11 @@ $(BUILD_DIR)/coverage.xml: test-kavm-avm-simulation
 $(BUILD_DIR)/coverage.html: $(BUILD_DIR)/coverage.xml
 	$(VENV_ACTIVATE) && pycobertura show --format html $(BUILD_DIR)/coverage.xml > $(BUILD_DIR)/coverage.html
 
+transient-coverage:
+	$(VENV_ACTIVATE) && $(KCOVR) $(KAVM_DEFINITION_DIR) \
+        -- $(avm_includes) $(plugin_includes) > $(BUILD_DIR)/coverage.xml
+	$(KAVM_SCRIPTS)/post-process-coverage $(BUILD_DIR)/coverage.xml
+
 coverage-html: $(BUILD_DIR)/coverage.html
 
 # remove coverage execution logs from the kompiled directory


### PR DESCRIPTION
This small PR:
* Changes the Dockerfile to use K's Ubuntu Jammy image so we could get newer `bison` version
* Adds a `transient-coverage` Makefile target that generates a coverage report based on what is now in the `-kompiled` directory