### PR TITLE
Support for more initial state setup in json scenarios

### DIFF
--- a/kavm/src/kavm/scenario.py
+++ b/kavm/src/kavm/scenario.py
@@ -30,6 +30,8 @@ class KAVMScenario:
                 acc['created-apps'] = KAVMScenario.sanitize_apps(acc['created-apps'])
             if not acc['created-assets']:
                 acc['created-assets'] = []
+            if not acc['apps-local-state']:
+                acc['apps-local-state'] = []
             result.append(acc)
         return result
 

--- a/lib/include/kframework/avm/algod/algod-models.md
+++ b/lib/include/kframework/avm/algod/algod-models.md
@@ -247,6 +247,31 @@ TODO: if an account contains an app, the state specification must also contain t
 ### Applications
 
 ```k
+
+    syntax KItem ::= #loadGlobalState(Int, JSONs)
+    //-------------------------------------------
+    rule <k> #loadGlobalState(APP_ID, {"key": K:String, "value": {"type": 1, "bytes": V:String, _} }, REST:JSONs ) => #loadGlobalState(APP_ID, REST) ... </k>
+         <app>
+           <appID> APP_ID </appID>
+           <globalState>
+             <globalBytes> .Map => (String2Bytes(K) |-> String2Bytes(V)) ... </globalBytes>
+             ...
+           </globalState>
+           ...
+         </app>
+
+    rule <k> #loadGlobalState(APP_ID, {"key": K:String, "value": {"type": 2, _, "uint": V:Int} }, REST:JSONs ) => #loadGlobalState(APP_ID, REST) ... </k>
+         <app>
+           <appID> APP_ID </appID>
+           <globalState>
+             <globalInts> .Map => (String2Bytes(K) |-> V) ... </globalInts>
+             ...
+           </globalState>
+           ...
+         </app>
+
+    rule <k> #loadGlobalState(_, .JSONs) => . ... </k>
+    
     syntax KItem ::= #setupApplications(JSON)
     //---------------------------------------
 
@@ -262,10 +287,10 @@ TODO: if an account contains an app, the state specification must also contain t
                                              , "clear-state-program": CLEAR_STATE_NAME:String
                                              , "local-state-schema" : { "nui": LOCAL_NUM_UINTS:Int, "nbs": LOCAL_NUM_BYTES:Int }
                                              , "global-state-schema": { "nui": GLOBAL_NUM_UINTS:Int, "nbs": GLOBAL_NUM_BYTES:Int }
-                                             , "global-state"       : _GLOBAL_STATE
+                                             , "global-state"       : [GLOBAL_STATE:JSONs]
                                              }
                                  }
-             ) => .K ... </k>
+             ) => #loadGlobalState(APP_ID, GLOBAL_STATE) ... </k>
            <account>
              <address> CREATOR_ADDR </address>
              <appsCreated>

--- a/lib/include/kframework/avm/algod/algod-models.md
+++ b/lib/include/kframework/avm/algod/algod-models.md
@@ -37,6 +37,34 @@ TODO: if an account contains an app, the state specification must also contain t
 ```
 
 ```k
+    syntax KItem ::= #setupOptInAssets(Bytes, JSONs)
+    //----------------------------------------------
+    rule <k> #setupOptInAssets(ADDR:Bytes, (
+                          {
+                            "amount": AMOUNT:Int,
+                            "asset-id": ASSET_ID:Int,
+                            "is-frozen": FROZEN:Bool
+                          }, REST:JSONs):JSONs)
+            => #setupOptInAssets(ADDR, REST)
+            ...
+          </k>
+          <account>
+            <address> ADDR </address>
+            <assetsOptedIn>
+              (.Bag =>
+              <optInAsset>
+                <optInAssetID> ASSET_ID </optInAssetID>
+                <optInAssetBalance> AMOUNT </optInAssetBalance>
+                <optInAssetFrozen> bool2Int(FROZEN) </optInAssetFrozen>
+              </optInAsset>)
+              ...
+            </assetsOptedIn>
+            ...
+          </account>
+
+    rule <k> #setupOptInAssets(_:Bytes, .JSONs) => . ... </k>
+
+
     syntax KItem ::= #addAccountJSON(JSON)
     //------------------------------------
     rule <k> #addAccountJSON({"address": ADDR:String,
@@ -44,7 +72,7 @@ TODO: if an account contains an app, the state specification must also contain t
                               "amount-without-pending-rewards": null,
                               "apps-local-state": [LOCAL_STATE:JSONs],
                               "apps-total-schema": null,
-                              "assets": null,
+                              "assets": [OPTIN_ASSETS:JSONs],
                               "created-apps": [APPS:JSONs],
                               "created-assets": [ASSETS:JSONs],
                               "participation": null,
@@ -56,7 +84,12 @@ TODO: if an account contains an app, the state specification must also contain t
                               "sig-type": null,
                               "auth-addr": null
                              })
-          => #setupApplications([APPS]) ~> #loadLocalState(DecodeAddressString(ADDR), LOCAL_STATE) ~> #setupAssets([ASSETS]) ... </k>
+            => #setupApplications([APPS]) 
+            ~> #loadLocalState(DecodeAddressString(ADDR), LOCAL_STATE) 
+            ~> #setupAssets([ASSETS]) 
+            ~> #setupOptInAssets(DecodeAddressString(ADDR), OPTIN_ASSETS)
+            ... 
+         </k>
          <accountsMap>
            (.Bag =>
            <account>
@@ -248,8 +281,6 @@ TODO: if an account contains an app, the state specification must also contain t
 
 ```k
     syntax KItem ::= #loadLocalState(Bytes, JSONs)
-//    rule <k> #loadLocalState(ADDR, (_:JSON) ) => "abcd" ... </k>
-//    rule <k> #loadLocalState(_:Bytes, ({"id": APP_ID:Int, "schema": _, "key-value": _}, REST):JSONs) => "abcd" ... </k>
 
     rule <k> #loadLocalState(ADDR:Bytes, 
                   {

--- a/tests/json-scenarios/asset-holding-setup.json
+++ b/tests/json-scenarios/asset-holding-setup.json
@@ -1,0 +1,80 @@
+{
+    "stages": [
+        {
+            "stage-type": "setup-network",
+            "data": {
+                "accounts": [
+                    {
+                        "address": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                        "amount": 200000,
+                        "created-apps": [],
+                        "created-assets": [
+                            {
+                                "index": 1,
+                                "params": {
+                                    "clawback": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+                                    "creator": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                                    "decimals": 0,
+                                    "default-frozen": false,
+                                    "freeze": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+                                    "manager": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                                    "metadata-hash": "",
+                                    "name": "testcoin",
+                                    "reserve": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" ,
+                                    "total": 123456,
+                                    "unit-name": "testcoins",
+                                    "url": ""
+                                }
+                            }
+                        ],
+                        "assets": []
+                    },
+                    {
+                        "address": "VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA",
+                        "amount": 200000,
+                        "created-apps": [],
+                        "created-assets": [],
+                        "assets": [
+                            {
+                                "amount": 12345,
+                                "asset-id": 1,
+                                "is-frozen": false
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "stage-type": "execute-transactions",
+            "data": {
+                "transactions": [
+                    {
+                        "snd": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                        "type": "appl",
+                        "apid": 0,
+                        "apan": 0,
+                        "apat": ["VCMJKWOY5P5P7SKMZFFOCEROPJCZOTIJMNIYNUCKH7LRO45JMJP6UYBIJA"],
+                        "apaa": [],
+                        "apfa": [],
+                        "apas": [1],
+                        "apbx": [],
+                        "apgs": {
+                            "nui": 0,
+                            "nbs": 0
+                        },
+                        "apls": {
+                            "nui": 0,
+                            "nbs": 0
+                        },
+                        "apep": 0,
+                        "apap": "asset-holding-setup.teal",
+                        "apsu": "clear-basic.teal"
+                    }
+                ]
+            },
+            "expected-returncode": 0,
+            "expected-paniccode": 0
+        }
+    ]
+}

--- a/tests/json-scenarios/fund-app-account.json
+++ b/tests/json-scenarios/fund-app-account.json
@@ -22,7 +22,7 @@
                       "nui": 0,
                       "nbs": 0
                   },
-                  "global-state": null
+                  "global-state": []
                 }
               }
             ],

--- a/tests/json-scenarios/global-storage-setup.json
+++ b/tests/json-scenarios/global-storage-setup.json
@@ -1,0 +1,70 @@
+{
+    "stages": [
+        {
+            "stage-type": "setup-network",
+            "data": {
+                "accounts": [
+                    {
+                        "address": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                        "amount": 200000,
+                        "created-apps": [
+                            {
+                                "id": 1,
+                                "params": { 
+                                    "creator": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                                    "approval-program": "global-storage-setup.teal",
+                                    "clear-state-program": "clear-basic.teal",
+                                    "local-state-schema": { 
+                                        "nui": 0,
+                                        "nbs": 0
+                                    }, 
+                                    "global-state-schema": { 
+                                        "nui": 3,
+                                        "nbs": 0
+                                    },
+                                    "global-state": [
+                                       { "key": "key1", "value": {"type": 2, "bytes": "", "uint": 1 }},
+                                       { "key": "key2", "value": {"type": 1, "bytes": "two", "uint": 0 }},
+                                       { "key": "key3", "value": {"type": 2, "bytes": "", "uint": 3 }}
+                                    ]
+                                }
+                            }
+                        ],
+                        "created-assets": []
+                    }
+                ]
+            }
+        },
+        {
+            "stage-type": "execute-transactions",
+            "data": {
+                "transactions": [
+                    {
+                        "snd": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
+                        "type": "appl",
+                        "apid": 1,
+                        "apan": 0,
+                        "apat": [],
+                        "apaa": [],
+                        "apfa": [],
+                        "apas": [],
+                        "apbx": [],
+                        "apgs": {
+                            "nui": 0,
+                            "nbs": 0
+                        },
+                        "apls": {
+                            "nui": 0,
+                            "nbs": 0
+                        },
+                        "apep": 0,
+                        "apap": "global-storage-setup.teal",
+                        "apsu": "clear-basic.teal"
+                    }
+                ]
+            },
+            "expected-returncode": 0,
+            "expected-paniccode": 0
+        }
+    ]
+}

--- a/tests/json-scenarios/local-storage-setup.json
+++ b/tests/json-scenarios/local-storage-setup.json
@@ -12,25 +12,35 @@
                                 "id": 1,
                                 "params": { 
                                     "creator": "LVMR75YJKH4ATBQ6UFI6IUM2FMU7NNLDQRBKIMG6Q2QAAAXWLIIKWMZRPE",
-                                    "approval-program": "global-storage-setup.teal",
+                                    "approval-program": "local-storage-setup.teal",
                                     "clear-state-program": "clear-basic.teal",
                                     "local-state-schema": { 
-                                        "nui": 0,
-                                        "nbs": 0
-                                    }, 
-                                    "global-state-schema": { 
                                         "nui": 2,
                                         "nbs": 1
+                                    }, 
+                                    "global-state-schema": { 
+                                        "nui": 0,
+                                        "nbs": 0
                                     },
-                                    "global-state": [
-                                       { "key": "key1", "value": {"type": 2, "bytes": "", "uint": 1 }},
-                                       { "key": "key2", "value": {"type": 1, "bytes": "two", "uint": 0 }},
-                                       { "key": "key3", "value": {"type": 2, "bytes": "", "uint": 3 }}
-                                    ]
+                                    "global-state": []
                                 }
                             }
                         ],
-                        "created-assets": []
+                        "created-assets": [],
+                        "apps-local-state": [
+                            {
+                                "id": 1,
+                                "schema": {
+                                    "num-uint": 2,
+                                    "num-byte-slice": 1
+                                },
+                                "key-value": [
+                                     { "key": "key1", "value": {"type": 2, "bytes": "", "uint": 1 }},
+                                     { "key": "key2", "value": {"type": 1, "bytes": "two", "uint": 0 }},
+                                     { "key": "key3", "value": {"type": 2, "bytes": "", "uint": 3 }}
+                                ]
+                            }
+                        ]
                     }
                 ]
             }
@@ -58,7 +68,7 @@
                             "nbs": 0
                         },
                         "apep": 0,
-                        "apap": "global-storage-setup.teal",
+                        "apap": "local-storage-setup.teal",
                         "apsu": "clear-basic.teal"
                     }
                 ]

--- a/tests/teal-sources/asset-holding-setup.teal
+++ b/tests/teal-sources/asset-holding-setup.teal
@@ -1,0 +1,12 @@
+#pragma version 8
+
+txn Accounts 1
+txn Assets 0
+asset_holding_get AssetBalance
+assert
+int 12345
+==
+assert
+
+int 1
+return

--- a/tests/teal-sources/global-storage-setup.teal
+++ b/tests/teal-sources/global-storage-setup.teal
@@ -1,0 +1,22 @@
+#pragma version 8
+
+byte "key1"
+app_global_get
+int 1
+==
+assert
+
+byte "key2"
+app_global_get
+byte "two"
+==
+assert
+
+byte "key3"
+app_global_get
+int 3
+==
+assert
+
+int 1
+return

--- a/tests/teal-sources/local-storage-setup.teal
+++ b/tests/teal-sources/local-storage-setup.teal
@@ -1,0 +1,25 @@
+#pragma version 8
+
+txn Sender
+byte "key1"
+app_local_get
+int 1
+==
+assert
+
+txn Sender
+byte "key2"
+app_local_get
+byte "two"
+==
+assert
+
+txn Sender
+byte "key3"
+app_local_get
+int 3
+==
+assert
+
+int 1
+return


### PR DESCRIPTION
This PR makes it so that local and global state can be set in the `setup-network` stage, and also that assets can be created and different users' balances set. What still needs to be done is adding a mechanism to check certain invariants. These are usually simple Ints such as `min-balance` which depend on the rest of the account's state but will be provided from the previous round. The other ones are counts of resources used. I am also removing the behavior of automatically opting in the creator of an asset when that asset appears in `setup-network`, because the user may want to set up a scenario where the asset is distributed among multiple accounts, and we need to be able to specify the creator's initial asset holdings. I am wondering if we should also check during the setup stage that the asset total correctly represents the sum of all the holdings of that asset.