### PR TITLE
Convert to using `total` instead of `functional`

### DIFF
--- a/lib/include/kframework/avm/algod/algod-models.md
+++ b/lib/include/kframework/avm/algod/algod-models.md
@@ -417,7 +417,7 @@ TODO: if an account contains an app, the state specification must also contain t
          </appsCreated>)
       => #dumpAppsImpl((CREATOR:String), (#dumpAppJSON((CREATOR:String), <app> APP </app>) , SERIALIZED) , <appsCreated> REST </appsCreated>)
     rule #dumpAppsImpl(
-         (CREATOR:String),
+         (_CREATOR:String),
          (SERIALIZED:JSONs),
          <appsCreated>
            .Bag
@@ -444,7 +444,7 @@ TODO: if an account contains an app, the state specification must also contain t
                  <localNumInts>    LOCAL_NUM_UINTS       </localNumInts>
                  <localNumBytes>   LOCAL_NUM_BYTES       </localNumBytes>
                </localState>
-               <extraPages>        EXTRA_PAGES           </extraPages>
+               <extraPages>        _EXTRA_PAGES           </extraPages>
                ...
              </app>)
           => { "id": APP_ID
@@ -710,7 +710,7 @@ TODO: if an account contains an app, the state specification must also contain t
        <tealPrograms> TEAL_PROGRAMS </tealPrograms>
        <nextTxnID> ID => ID +Int 1 </nextTxnID>
 
-    syntax MaybeTValue ::= progamFromJSON(JSON) [function, functional]
+    syntax MaybeTValue ::= progamFromJSON(JSON) [function, total]
     //----------------------------------------------------------------
     rule progamFromJSON(PGM:String) => PGM
     rule progamFromJSON(_)          => NoTValue [owise]
@@ -777,7 +777,7 @@ TODO: if an account contains an app, the state specification must also contain t
          </transaction>)
          TXNS
        </transactions>
-       <tealPrograms> TEAL_PROGRAMS </tealPrograms>
+       <tealPrograms> _TEAL_PROGRAMS </tealPrograms>
        <nextTxnID> ID => ID +Int 1 </nextTxnID>
 ```
 

--- a/lib/include/kframework/avm/avm-execution.md
+++ b/lib/include/kframework/avm/avm-execution.md
@@ -736,8 +736,8 @@ Not supported.
        <transaction>
          <txID>                 TXN_ID              </txID>
          <sender>               SENDER              </sender>
-         <freezeAccount>        FREEZE_ACCOUNT       </freezeAccount>
-         <freezeAsset>          ASSET               </freezeAsset>
+         <freezeAccount>        FREEZE_ACCOUNT      </freezeAccount>
+         <freezeAsset>          ASSET_ID            </freezeAsset>
          <assetFrozen>          FREEZE              </assetFrozen>
          ...
        </transaction>

--- a/lib/include/kframework/avm/avm-initialization.md
+++ b/lib/include/kframework/avm/avm-initialization.md
@@ -29,7 +29,7 @@ AVM Initialization
 To know the group size, we need to count the transactions in the group:
 
 ```k
-  syntax Int ::= countTxns(TransactionsCell) [function, functional]
+  syntax Int ::= countTxns(TransactionsCell) [function, total]
   // --------------------------------------------------------------
 
   rule countTxns(<transactions> <transaction> _ </transaction> REST </transactions>)
@@ -37,7 +37,7 @@ To know the group size, we need to count the transactions in the group:
   rule countTxns(<transactions> .Bag </transactions>)
        => 0
 
-  syntax Int ::= countTxnsInGroup(TransactionsCell, String) [function, functional]
+  syntax Int ::= countTxnsInGroup(TransactionsCell, String) [function, total]
   // -----------------------------------------------------------------------------
 
   rule countTxnsInGroup(<transactions> <transaction> <groupID> GROUP </groupID> ... </transaction> REST </transactions>, GROUP)
@@ -112,13 +112,13 @@ Traverse the `<transactions>` cell and index the relation of group ids with tran
 
   rule <k> #initTxnIndexMap(.List) => .K ... </k>
 
-  syntax List ::= collectTxnIds(TransactionsCell) [function, functional]
+  syntax List ::= collectTxnIds(TransactionsCell) [function, total]
   //--------------------------------------------------------------------
   rule collectTxnIds(<transactions> .Bag </transactions>) => .List
   rule collectTxnIds(<transactions> <transaction> <txID> TXN_ID </txID> ... </transaction> TXNS </transactions>)
     => ListItem(TXN_ID) collectTxnIds(<transactions> TXNS </transactions>)
 
-  syntax Bool ::= "group_id_in_index_map" "(" String ")" [function, functional]
+  syntax Bool ::= "group_id_in_index_map" "(" String ")" [function, total]
   //---------------------------------------------------------------------------
   rule [[ group_id_in_index_map(GROUP_ID) => true ]]
        <txnIndexMapGroupKey> GROUP_ID </txnIndexMapGroupKey>

--- a/lib/include/kframework/avm/blockchain.md
+++ b/lib/include/kframework/avm/blockchain.md
@@ -264,7 +264,7 @@ Accessor functions
 ### Account State Accessors
 
 ```k
-  syntax MaybeTValue ::= getAccountParamsField(AccountParamsField, TValue)  [function, functional]
+  syntax MaybeTValue ::= getAccountParamsField(AccountParamsField, TValue)  [function, total]
   //----------------------------------------------------------------------------------------------
   rule [[ getAccountParamsField(AcctBalance, ADDR) => BAL ]]
        <account>
@@ -289,7 +289,7 @@ Accessor functions
 
   rule getAccountParamsField(_, _) => NoTValue  [owise]
 
-  syntax MaybeTValue ::= getAppParamsField(AppParamsField, Int) [function, functional]
+  syntax MaybeTValue ::= getAppParamsField(AppParamsField, Int) [function, total]
   //----------------------------------------------------------------------------------
   rule [[ getAppParamsField(AppApprovalProgram, APP) => X ]]
        <app>
@@ -403,7 +403,7 @@ Accessor functions
 ### Asset State Accessors
 
 ```k
-  syntax Bool ::= hasOptedInAsset(TValue, TValue) [function, functional]
+  syntax Bool ::= hasOptedInAsset(TValue, TValue) [function, total]
   // -----------------------------------------------------
   rule [[ hasOptedInAsset(ASSET, ADDR) => true ]]
        <account>
@@ -591,7 +591,7 @@ Accessor functions
     requires notBool (ADDR in_accounts(<accountsMap> AMAP </accountsMap>))
 
 
-  syntax MaybeTValue ::= getAppLocal(TValue, TValue, TValue) [function, functional]
+  syntax MaybeTValue ::= getAppLocal(TValue, TValue, TValue) [function, total]
   // ---------------------------------------------------------
   rule [[ getAppLocal(ADDR, APP, KEY) => V ]]
        <account>
@@ -811,7 +811,7 @@ Accessor functions
 
   rule _ in_assets(<assetsCreated> .Bag </assetsCreated>) => false
 
-  syntax Bool ::= TValue "in_apps" "(" AccountsMapCell ")" [function, functional]
+  syntax Bool ::= TValue "in_apps" "(" AccountsMapCell ")" [function, total]
   // ----------------------------------------------------------------------------
   rule APP in_apps(<accountsMap>
                      <account>
@@ -823,7 +823,7 @@ Accessor functions
 
   rule _ in_apps( <accountsMap> .Bag </accountsMap> ) => false
 
-  syntax Bool ::= TValue "in_apps" "(" AppsCreatedCell ")" [function, functional]
+  syntax Bool ::= TValue "in_apps" "(" AppsCreatedCell ")" [function, total]
   // ----------------------------------------------------------------------------
   rule APP in_apps(<appsCreated>
                      <app>
@@ -850,18 +850,18 @@ The purpose of `accountReference()`, `appReference()`, and `asaReference()` is t
 references and also to check that a resource is available.
 
 ```k
-  syntax MaybeTValue ::= accountReference(TValue) [function, functional]
+  syntax MaybeTValue ::= accountReference(TValue) [function, total]
   //--------------------------------------------------------------------
   rule accountReference(A:TBytes ) => A requires accountAvailable(A)
   rule accountReference(I:Int    ) => getTxnField(getCurrentTxn(), Accounts, I)
   rule accountReference(_        ) => NoTValue  [owise]
 
-  syntax MaybeTValue ::= appReference(TUInt64)  [function, functional]
+  syntax MaybeTValue ::= appReference(TUInt64)  [function, total]
   //-----------------------------------------------------------------
   rule appReference(I) => I requires applicationAvailable(I)
   rule appReference(I) => getTxnField(getCurrentTxn(), Applications, I)  [owise]
 
-  syntax MaybeTValue ::= asaReference(TUInt64)  [function, functional]
+  syntax MaybeTValue ::= asaReference(TUInt64)  [function, total]
   //------------------------------------------------------------------
   rule asaReference(I) => I requires assetAvailable(I)
   rule asaReference(I) => getTxnField(getCurrentTxn(), Assets, I)  [owise]
@@ -873,7 +873,7 @@ references and also to check that a resource is available.
 // TODO the associated account of a contract that was created earlier in the group should be available (v 6)
 // TODO the associated account of a contract present in the txn.ForeignApplications field should be available (v7)
 
-  syntax Bool ::= accountAvailable(TBytes) [function, functional]
+  syntax Bool ::= accountAvailable(TBytes) [function, total]
   //---------------------------------------------------------------
 
   rule accountAvailable(A) => true
@@ -890,7 +890,7 @@ references and also to check that a resource is available.
   
 // TODO any contract that was created earlier in the same transaction group should be available (v6)
 
-  syntax Bool ::= applicationAvailable(TUInt64) [function, functional]
+  syntax Bool ::= applicationAvailable(TUInt64) [function, total]
   //------------------------------------------------------------------
 
   rule applicationAvailable(A) => true
@@ -904,7 +904,7 @@ references and also to check that a resource is available.
 
 // TODO any asset that was created earlier in the same transaction group should be available (v6)
 
-  syntax Bool ::= assetAvailable(TUInt64) [function, functional]
+  syntax Bool ::= assetAvailable(TUInt64) [function, total]
   //------------------------------------------------------------
 
   rule assetAvailable(A) => true
@@ -912,7 +912,7 @@ references and also to check that a resource is available.
 
   rule assetAvailable(_) => false [owise]
 
-  syntax Map ::= TValuePairList2Map(TValuePairList, TValueList, Bytes) [function, functional]
+  syntax Map ::= TValuePairList2Map(TValuePairList, TValueList, Bytes) [function, total]
   //----------------------------------------------------------------------
   rule TValuePairList2Map((A, B):TValuePair REST, APPS, DEFAULT) => ((A |-> getAppAddressBytes({getTValueAt(B -Int 1, APPS)}:>Int)) TValuePairList2Map(REST, APPS, DEFAULT))
     requires B >=Int 1
@@ -922,9 +922,9 @@ references and also to check that a resource is available.
   rule TValuePairList2Map((A, 0):TValuePair, _, DEFAULT) => (A |-> DEFAULT)
   rule TValuePairList2Map(.TValuePairList, _, _) => .Map
 
-  syntax Map ::= getBoxRefs(String) [function, functional]
-  syntax Map ::= getGroupBoxRefs(String) [function, functional]
-  syntax Map ::= getGroupBoxRefs(Map) [function, functional]
+  syntax Map ::= getBoxRefs(String) [function, total]
+  syntax Map ::= getGroupBoxRefs(String) [function, total]
+  syntax Map ::= getGroupBoxRefs(Map) [function, total]
   //--------------------------------------------------------
 
   rule [[ getGroupBoxRefs(GROUP_ID) => getGroupBoxRefs(VALS) ]]
@@ -954,7 +954,7 @@ references and also to check that a resource is available.
          ...
        </transaction>
 
-  syntax MaybeTValue ::= boxAcct(Bytes) [function, functional]
+  syntax MaybeTValue ::= boxAcct(Bytes) [function, total]
   //--------------------------------------------------------------------
   rule boxAcct(NAME) => {getGroupBoxRefs(getTxnGroupID(getCurrentTxn()))[NAME]}:>Bytes
     requires NAME in_keys(getGroupBoxRefs(getTxnGroupID(getCurrentTxn())))

--- a/lib/include/kframework/avm/teal/teal-constants.md
+++ b/lib/include/kframework/avm/teal/teal-constants.md
@@ -65,7 +65,7 @@ actions occur when the transaction completes.
 ```
 
 ```k
-  syntax TValue ::= normalizeI(PseudoTUInt64) [function, functional]
+  syntax TValue ::= normalizeI(PseudoTUInt64) [function, total]
   // ---------------------------------------------------------------
   rule normalizeI(V:TUInt64) => V
 

--- a/lib/include/kframework/avm/teal/teal-driver.md
+++ b/lib/include/kframework/avm/teal/teal-driver.md
@@ -191,7 +191,7 @@ Opcode Semantics
     requires isBytes(I1) orBool isBytes(I2) orBool isBytes(I3)
 
   // Auxilary funtion that interprets two `UInt64` as one Int, big-endian
-  syntax Int ::= asUInt128(TUInt64, TUInt64) [function, functional]
+  syntax Int ::= asUInt128(TUInt64, TUInt64) [function, total]
   // --------------------------------------------------------------
   rule asUInt128(I1, I2) => (I1 <<Int 64) +Int I2
 

--- a/lib/include/kframework/avm/teal/teal-stack.md
+++ b/lib/include/kframework/avm/teal/teal-stack.md
@@ -25,7 +25,7 @@ The elements of the stack are values of sort `TValue`, i.e. either `TUInt64` or 
 - `#drop(N , WS)` removes the first $N$ elements of a `TStack`.
 
 ```k
-  syntax TStack ::= #take ( Int , TStack ) [klabel(takeTStack), function, functional]
+  syntax TStack ::= #take ( Int , TStack ) [klabel(takeTStack), function, total]
   // --------------------------------------------------------------------------------------------
   rule [#take.zero]:      #take(N, _Stack)          => .TStack
     requires N <=Int 0
@@ -34,7 +34,7 @@ The elements of the stack are values of sort `TValue`, i.e. either `TUInt64` or 
   rule [#take.recursive]: #take(N, (X : XS):TStack) => X : #take(N -Int 1, XS)
     requires N >Int 0
 
-  syntax TStack ::= #drop ( Int , TStack ) [klabel(dropTStack), function, functional]
+  syntax TStack ::= #drop ( Int , TStack ) [klabel(dropTStack), function, total]
   // --------------------------------------------------------------------------------------------
   rule #drop(N, XS:TStack)       => XS
     requires N <=Int 0
@@ -73,8 +73,8 @@ The elements of the stack are values of sort `TValue`, i.e. either `TUInt64` or 
 ```
 
 ```k
-  syntax Int ::= #sizeTStack ( TStack )       [function, functional, smtlib(sizeTStack)]
-               | #sizeTStack ( TStack , Int ) [function, functional, klabel(sizeTStackAux),
+  syntax Int ::= #sizeTStack ( TStack )       [function, total, smtlib(sizeTStack)]
+               | #sizeTStack ( TStack , Int ) [function, total, klabel(sizeTStackAux),
                                                smtlib(sizeTStackAux)]
   // --------------------------------------------------------------------------------------------
   rule #sizeTStack ( XS ) => #sizeTStack(XS, 0)
@@ -85,8 +85,8 @@ The elements of the stack are values of sort `TValue`, i.e. either `TUInt64` or 
 ## Stack reverse
 
 ```k
-  syntax TStack ::= #reverse(TStack)         [function, functional]
-                  | #reverse(TStack, TStack) [function, functional]
+  syntax TStack ::= #reverse(TStack)         [function, total]
+                  | #reverse(TStack, TStack) [function, total]
   // --------------------------------------------------------------
   rule #reverse(XS)          => #reverse(XS, .TStack)
   rule #reverse(.TStack, YS) => YS
@@ -96,8 +96,8 @@ The elements of the stack are values of sort `TValue`, i.e. either `TUInt64` or 
 ## Stack concatenation
 
 ```k
-  syntax TStack ::= TStack TStack                    [function, functional]
-                 | #concatTStackImpl(TStack, TStack) [function, functional]
+  syntax TStack ::= TStack TStack                    [function, total]
+                 | #concatTStackImpl(TStack, TStack) [function, total]
   // ------------------------------------------------------------------------------
   rule XS YS => #concatTStackImpl(#reverse(XS), YS)
 

--- a/lib/include/kframework/avm/teal/teal-types.md
+++ b/lib/include/kframework/avm/teal/teal-types.md
@@ -162,8 +162,8 @@ It is sometimes useful to go from the byte representation back to the token.
 We use several hooks which convert between token and string representations.
 
 ```k
-  syntax String          ::= TealAddress2String(TAddressLiteral) [function, functional, hook(STRING.token2string)]
-  syntax String          ::= Hex2String(HexToken)                [function, functional, hook(STRING.token2string)]
+  syntax String          ::= TealAddress2String(TAddressLiteral) [function, total, hook(STRING.token2string)]
+  syntax String          ::= Hex2String(HexToken)                [function, total, hook(STRING.token2string)]
   syntax TAddressLiteral ::= String2TealAddress(String)          [function, hook(STRING.string2token)]
   syntax HexToken        ::= String2Hex(String)                  [function, hook(STRING.string2token)]
 ```
@@ -191,11 +191,11 @@ Application addresses are constructed by hashing the application ID in a specail
 See also [this section](https://developer.algorand.org/docs/get-details/dapps/smart-contracts/apps/#issuing-transactions-from-an-application) of the Algorand documentation.
 
 ```k
-  syntax Bytes ::= getAppAddressBytes(Int) [function, functional]
+  syntax Bytes ::= getAppAddressBytes(Int) [function, total]
   //-------------------------------------------------------------
   rule getAppAddressBytes(APP_ID) => String2Bytes(Sha512_256raw(Bytes2String(b"appID" +Bytes Int2Bytes(8, APP_ID, BE))))
 
-  syntax TAddressLiteral ::= getAppAddress(Int) [function, functional]
+  syntax TAddressLiteral ::= getAppAddress(Int) [function, total]
   //------------------------------------------------------------------
   rule getAppAddress(APP_ID) => String2TealAddress(EncodeAddressBytes(getAppAddressBytes(APP_ID)))
 ```
@@ -225,14 +225,14 @@ We expose several functions for working with lists.
   rule size(_:TValue       ) => 1
   rule size(.TValueList    ) => 0
 
-  syntax Bool ::= contains(TValueList, TValue) [function, functional]
+  syntax Bool ::= contains(TValueList, TValue) [function, total]
   // ----------------------------------------------------------------
   rule contains(V1:TValue  _:TValueNeList, V1:TValue) => true
   rule contains(V1:TValue VL:TValueNeList, V2:TValue) => contains(VL, V2) requires V1 =/=K V2
   rule contains(V1:TValue                , V2:TValue) => V1 ==K V2
   rule contains(              .TValueList,  _:TValue) => false 
 
-  syntax Bool ::= contains(TValuePairList, TValuePair) [function, functional]
+  syntax Bool ::= contains(TValuePairList, TValuePair) [function, total]
   // ----------------------------------------------------------------
   rule contains(V1:TValuePair  _:TValuePairNeList, V1:TValuePair) => true
   rule contains(V1:TValuePair VL:TValuePairNeList, V2:TValuePair) => contains(VL, V2) requires V1 =/=K V2
@@ -275,7 +275,7 @@ We expose several functions for working with lists.
   rule append(V, V':TValuePair VL) => V' append(V, VL)
   rule append(V, V':TValuePair   ) => V' V
 
-  syntax TValueList ::= convertToBytes(TValueList) [function, functional]
+  syntax TValueList ::= convertToBytes(TValueList) [function, total]
   //---------------------------------------------------------------------
   rule convertToBytes(.TValueList) => .TValueList
   rule convertToBytes(B:TBytes) => B
@@ -283,12 +283,12 @@ We expose several functions for working with lists.
   rule convertToBytes(B:TBytes L:TValueNeList) => (B {convertToBytes(L)}:>TValueNeList)
   rule convertToBytes(I:TUInt64 L:TValueNeList) => (Int2Bytes({I}:>Int, BE, Unsigned) {convertToBytes(L)}:>TValueNeList)
 
-  syntax Int ::= sizeInBytes(TValue) [function, functional]
+  syntax Int ::= sizeInBytes(TValue) [function, total]
   //-------------------------------------------------------
   rule sizeInBytes(_:TUInt64) => 64
   rule sizeInBytes(B:TBytes) => lengthBytes({B}:>Bytes)
 
-  syntax Int ::= maybeTUInt64(MaybeTValue, Int) [function, functional]
+  syntax Int ::= maybeTUInt64(MaybeTValue, Int) [function, total]
   //------------------------------------------------------------------
   rule maybeTUInt64(X, _)       => X       requires isTUInt64(X)
   rule maybeTUInt64(_, DEFAULT) => DEFAULT [owise]
@@ -307,11 +307,11 @@ our internal K representation:
 ### Boolean conversions
 
 ```k
-  syntax Bool ::= int2Bool(Int) [function, functional]
+  syntax Bool ::= int2Bool(Int) [function, total]
   rule int2Bool(0) => false
   rule int2Bool(A) => true requires A =/=Int 0
 
-  syntax Int ::= bool2Int(Bool)  [function, functional, smtlib(bool2Int)]
+  syntax Int ::= bool2Int(Bool)  [function, total, smtlib(bool2Int)]
   rule bool2Int(true ) => 1
   rule bool2Int(false) => 0
 ```

--- a/lib/include/kframework/avm/txn.md
+++ b/lib/include/kframework/avm/txn.md
@@ -210,7 +210,7 @@ module ALGO-TXN
 *Transaction ID Getter*
 
 ```k
-  syntax String ::= getTxID(TransactionCell) [function, functional]
+  syntax String ::= getTxID(TransactionCell) [function, total]
   //---------------------------------------------------------------
   rule getTxID(<transaction> <txID> ID </txID> ... </transaction>) => ID
 ```
@@ -890,8 +890,8 @@ module ALGO-TXN
   rule _ in_txns( <transactions> .Bag </transactions> ) => false
 
 
-  syntax Bool ::= #isValidForTxnType(TxnField,     Int) [function, functional]
-  syntax Bool ::= #isValidForTxnType(TxnaField,    Int) [function, functional]
+  syntax Bool ::= #isValidForTxnType(TxnField,     Int) [function, total]
+  syntax Bool ::= #isValidForTxnType(TxnaField,    Int) [function, total]
   // -------------------------------------------------------------
   // all transaction types
   rule #isValidForTxnType(_:TxnHeaderField  , I)    => 1 <=Int I andBool I <=Int 6


### PR DESCRIPTION
The `functional` attribute was deprecated on symbols. Now we use `total` to denote a total function.