### PR TITLE
[nix] fix master-push CI

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,8 +1,8 @@
 name: 'Master Push'
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
 
 jobs:
   nix-flake-release:
@@ -41,13 +41,12 @@ jobs:
           skipPush: true
 
       - name: 'Build and cache kavm'
-        uses: workflow/nix-shell-action@v3
+        # uses: workflow/nix-shell-action@v3
         env:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: '${{  secrets.CACHIX_PUBLIC_TOKEN }}'
-        with:
-          packages: jq
-          script: |
-            kavm=$(nix build .#kavm --json | jq -r '.[].outputs | to_entries[].value')
-            drv=$(nix-store --query --deriver ${kavm})
-            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
+        run: |
+          nix shell nixpkgs#jq
+          kavm=$(nix build .#kavm --json | jq -r '.[].outputs | to_entries[].value')
+          drv=$(nix-store --query --deriver ${kavm})
+          nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -46,7 +46,7 @@ jobs:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: '${{  secrets.CACHIX_PUBLIC_TOKEN }}'
         run: |
-          nix shell nixpkgs#jq
-          kavm=$(nix build .#kavm --json | jq -r '.[].outputs | to_entries[].value')
+          nix build nixpkgs#jq -o jq
+          kavm=$(nix build .#kavm --json | ./jq -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${kavm})
           nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: '${{  secrets.CACHIX_PUBLIC_TOKEN }}'
+          NIX_PATH: 'nixpkgs=http://nixos.org/channels/nixos-22.05/nixexprs.tar.xz'
         run: |
           export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
           kavm=$(nix build .#kavm --json | $JQ -r '.[].outputs | to_entries[].value')

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -46,7 +46,7 @@ jobs:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: '${{  secrets.CACHIX_PUBLIC_TOKEN }}'
         run: |
-          nix build nixpkgs#jq -o jq
-          kavm=$(nix build .#kavm --json | ./jq -r '.[].outputs | to_entries[].value')
+          export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
+          kavm=$(nix build .#kavm --json | $JQ -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${kavm})
           nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -1,8 +1,8 @@
 name: 'Master Push'
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
 
 jobs:
   nix-flake-release:
@@ -41,7 +41,6 @@ jobs:
           skipPush: true
 
       - name: 'Build and cache kavm'
-        # uses: workflow/nix-shell-action@v3
         env:
           GC_DONT_GC: 1
           CACHIX_AUTH_TOKEN: '${{  secrets.CACHIX_PUBLIC_TOKEN }}'


### PR DESCRIPTION
the nix-shell action seemed to be the culprit in failing master job. removed and replaced with custom `jq` command.